### PR TITLE
Fix websocket auth guard and align API tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 SOMA Project - Common test fixtures and utilities
 """
 
+import importlib
 import os
 import sys
 import time
@@ -16,6 +17,20 @@ sys.path.append(str(Path(__file__).parent.parent))
 sys.path.append(str(Path(__file__).parent.parent / "scripts"))
 # Add src/ for packages like rince
 sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+# Ensure legacy "auth" package imports resolve to backend.auth for compatibility
+backend_auth_pkg = importlib.import_module("backend.auth")
+sys.modules.setdefault("auth", backend_auth_pkg)
+sys.modules.setdefault(
+    "auth.jwt_utils", importlib.import_module("backend.auth.jwt_utils")
+)
+sys.modules.setdefault(
+    "auth.models", importlib.import_module("backend.auth.models")
+)
+sys.modules.setdefault(
+    "memory_timeline", importlib.import_module("backend.memory_timeline")
+)
+sys.modules.setdefault("metrics", importlib.import_module("backend.metrics"))
 
 # Import SOMA modules
 from scripts.consciousness_maturation import (ConsciousnessMaturationSystem,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from fastapi.testclient import TestClient
+
 from backend.api import app
 
 
@@ -13,10 +15,11 @@ class TestAPIUnit:
 
     def test_health_endpoint(self):
         """Test health endpoint returns 200"""
-        with app.test_client() as client:
-            response = client.get("/health")
-            assert response.status_code == 200
-            assert b"OK" in response.data
+        client = TestClient(app)
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"].lower() == "ok"
 
     def test_websocket_connection_unit(self):
         """Test WebSocket connection establishment (unit level)"""


### PR DESCRIPTION
## Summary
- skip JSON parsing when websocket connections are already authenticated via URL token
- add a graceful bcrypt fallback in the JWT utilities so tests run without the native backend
- update API unit/integration tests and shared conftest aliases to use FastAPI's TestClient and available modules

## Testing
- pytest tests/unit/test_api.py tests/integration/test_api_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e1633d0d3c832d8b3d6ecced1ac8ff