### PR TITLE
Consolidate dev dependencies and remove pytest-asyncio from CI

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -21,8 +21,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel setuptools
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
         # optional client libs for ws tests
-        pip install websockets requests pytest-asyncio
+        pip install websockets requests
 
     - name: Start backend (uvicorn on 8080) and wait readiness
       run: |


### PR DESCRIPTION
## Summary
Updated the CI workflow to consolidate development dependencies and remove an unused test dependency from the integration test setup.

## Key Changes
- Added `pip install -r requirements-dev.txt` to install all development dependencies in one place
- Removed `pytest-asyncio` from the inline pip install command as it's now included in requirements-dev.txt
- Kept `websockets` and `requests` as they are optional client libraries specifically needed for WebSocket tests

## Details
This change improves dependency management by centralizing dev dependencies in the requirements-dev.txt file rather than scattering them across the CI workflow. The pytest-asyncio package is now installed via the requirements file, reducing duplication and making the CI configuration cleaner and easier to maintain.

https://claude.ai/code/session_01Y5Mj3RuCkqXDqTx2C3Lpak