### PR TITLE
docs: add Liminal ecosystem map and status package

### DIFF
--- a/COMMUNITY_ROADMAP.md
+++ b/COMMUNITY_ROADMAP.md
@@ -1,0 +1,106 @@
+# Community Roadmap
+
+This roadmap turns the Liminal ecosystem into a clear, contributor-friendly project.
+
+---
+
+## Phase 1 — Clarity
+
+**Goal:** make the ecosystem understandable for new readers.
+
+Tasks:
+
+- Rewrite the root README as a canonical entry point
+- Add `ECOSYSTEM.md`
+- Add `STATUS.md`
+- Add glossary of core terms
+- Add repository descriptions
+- Add architecture diagram
+- Add links to related repositories
+
+Definition of done:
+
+A new visitor can understand the project, its subprojects, and its current maturity without talking to the founder.
+
+---
+
+## Phase 2 — Developer Entry
+
+**Goal:** give developers a concrete starting point.
+
+Tasks:
+
+- Add local setup guide
+- Add quickstart demo
+- Add API documentation
+- Add WebSocket examples
+- Add test instructions
+- Add good-first-issues
+- Add contributor guide
+
+Definition of done:
+
+A developer can clone the repository, run a local check, and pick a first useful task.
+
+---
+
+## Phase 3 — Commercial Demo
+
+**Goal:** show practical value with one sharp story.
+
+Demo concept:
+
+From unstable agent behavior to auditable execution.
+
+Tasks:
+
+- Build Liminal Agent Efficiency Audit page
+- Connect LTP + CML + CaPU narrative
+- Prepare sample trace
+- Show detected drift
+- Show missing permission chain
+- Show unsafe action blocked or held
+- Generate audit report
+
+Definition of done:
+
+A potential client can understand the value in three minutes.
+
+---
+
+## Phase 4 — Public Launch
+
+**Goal:** make Liminal understandable to investors, researchers, and builders.
+
+Tasks:
+
+- Landing page refresh
+- Short demo video
+- Technical whitepaper
+- GitHub pinned repositories
+- Community call for contributors
+- First audit case study
+
+Definition of done:
+
+The project can be shared publicly without requiring a long private explanation.
+
+---
+
+## Suggested good-first-issues
+
+- Improve glossary explanations
+- Add Mermaid diagrams
+- Add WebSocket quickstart examples
+- Add docs links between repositories
+- Add test command examples
+- Review README clarity
+- Create short demo scripts
+
+---
+
+## Current constraint
+
+Do not expand the ecosystem before the current one is understandable.
+
+The immediate work is packaging, clarity, and one compelling demo path.

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,142 @@
+# Liminal Ecosystem
+
+**Liminal** is an ecosystem for continuity in human and AI systems.
+
+It connects two related problems:
+
+1. Humans lose continuity in transitions: stress, uncertainty, emotional overload, unclear intent.
+2. AI agents lose continuity across context, memory, permission, traces, and action execution.
+
+Liminal explores both sides: human transition support and auditable AI-agent infrastructure.
+
+---
+
+## Core thesis
+
+Modern systems break continuity.
+
+- Humans need support when moving from anxiety to clarity.
+- AI agents need traces, causal memory, and safe execution boundaries.
+- Logs show what happened, but often not why it was allowed.
+- Agent outputs can look correct while their causal lineage is invalid.
+
+Liminal is the umbrella for tools that make transitions visible, traceable, and safer.
+
+---
+
+## Ecosystem map
+
+| Layer | Repository | Purpose | Status |
+|---|---|---|---|
+| Human Transition | [`Liminal`](https://github.com/safal207/Liminal) | Inner clarity, reflection, maturity, transition support | Early-access / root hub |
+| Agent Continuity | [`LTP`](https://github.com/safal207/L-THREAD-Liminal-Thread-Secure-Protocol-LTP-) | Deterministic replay and trace verification for AI agents | Active technical project |
+| Causal Memory | [`CML`](https://github.com/safal207/Causal-Memory-Layer) | Reasons, permissions, responsibility, causal audit | Active technical project |
+| Safe Action Runtime | [`CaPU`](https://github.com/safal207/CaPU) | Permission-first runtime: Gate → Incubate → Commit → Execute | Spec-first runtime |
+| Reactive Storage | [`LiminalDB`](https://github.com/safal207/LiminalBD) | Biologically inspired reactive state database | Active Rust project |
+| AI Routing | [`DAO_lim`](https://github.com/safal207/DAO_lim) | Intent-aware reverse proxy for AI backends, routing, fallback, observability | Active infra project |
+| QA Intelligence | [`LiminalQAengineer`](https://github.com/safal207/LiminalQAengineer) | Flake risk, adaptive timeouts, QA observability, merge decisions | Product/prototype direction |
+| Intent Clarification | [`DIF`](https://github.com/safal207/DIF) | DeepIntent Funnel: from raw signal to clarified intention | Separate project, not part of Liminal naming |
+
+---
+
+## High-level architecture
+
+```mermaid
+graph TD
+    Human[Human in transition] --> LiminalCore[Liminal Core]
+    LiminalCore --> Pulse[Liminal Pulse / Human UX]
+    LiminalCore --> InnerCouncil[Inner Council]
+    LiminalCore --> Maturity[Maturity Engine]
+
+    Agent[AI Agent] --> LTP[LTP: Trace Continuity]
+    LTP --> CML[CML: Causal Memory]
+    CML --> CaPU[CaPU: Safe Action Runtime]
+    CaPU --> Action[Auditable Action]
+
+    LiminalCore --> LiminalDB[LiminalDB: Reactive State]
+    LTP --> LiminalDB
+    CML --> LiminalDB
+    DAO[DAO_lim: Intent-aware Routing] --> Agent
+    QA[LiminalQAengineer] --> LTP
+    QA --> CML
+```
+
+---
+
+## Two main narratives
+
+### 1. Human narrative
+
+Liminal helps a person move from inner noise to clarified direction:
+
+- anxiety → clarity
+- raw emotion → reflection
+- fragmented state → inner continuity
+- reaction → mature action
+
+This direction includes Liminal Pulse, Inner Council, emotional memory, maturity signals, and self-dialogue.
+
+### 2. AI infrastructure narrative
+
+Liminal Stack helps AI-agent systems become replayable, causally valid, and auditable:
+
+- trace continuity through LTP
+- causal validity through CML
+- safe execution through CaPU
+- adaptive state through LiminalDB
+- routing and fallback through DAO_lim
+- QA intelligence through LiminalQAengineer
+
+---
+
+## Commercial entry point
+
+The first practical commercial entry point is:
+
+# Liminal Agent Efficiency Audit
+
+We audit AI-agent workflows and show where they lose:
+
+- context
+- money
+- safety
+- permission chains
+- replayability
+- audit evidence
+- test stability
+- routing efficiency
+
+Target users:
+
+- AI startups
+- agentic workflow teams
+- fintech teams
+- QA automation teams
+- LLM infrastructure teams
+- compliance-heavy companies
+
+---
+
+## Current priority
+
+The priority is not to create more repositories.
+
+The priority is to make the existing ecosystem understandable:
+
+1. clear root README
+2. honest status file
+3. ecosystem map
+4. community roadmap
+5. commercial audit page
+6. demo story
+7. developer quickstart
+
+---
+
+## Short positioning
+
+**Liminal is a continuity layer for human and AI transitions.**
+
+For humans, it helps preserve inner continuity during difficult transitions.
+
+For AI agents, it helps preserve technical continuity through traces, causal memory, and auditable execution.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,77 @@
 # Liminal
+
+**Continuity layer for human and AI transitions.**
+
+Liminal helps humans preserve inner continuity through difficult transitions, and helps AI agents preserve technical continuity through traces, causal memory, and auditable execution.
+
+---
+
+## Why it matters
+
+Modern systems break continuity:
+
+- humans lose clarity under stress
+- AI agents lose context across steps
+- actions happen without durable reasons
+- logs show events but not responsibility
+- agent behavior is hard to replay or audit
+
+Liminal is an ecosystem of tools for making transitions visible, traceable, and safer.
+
+---
+
+## Choose your path
+
+### I am a developer
+Start with LTP, CML, CaPU, LiminalDB, DAO_lim, and the local health/readiness checks below.
+
+### I am a researcher
+Read the continuity, causal memory, trace replay, and agent audit materials.
+
+### I am a founder or operator
+Start with [Liminal Agent Efficiency Audit](docs/commercial/AGENT_EFFICIENCY_AUDIT.md).
+
+### I am interested in human growth
+Start with Liminal Pulse, Inner Council, emotional memory, and transition support concepts.
+
+---
+
+## Ecosystem entry points
+
+- [Ecosystem map](ECOSYSTEM.md)
+- [Project status](STATUS.md)
+- [Community roadmap](COMMUNITY_ROADMAP.md)
+- [Documentation index](docs/README.md)
+- [Agent Efficiency Audit](docs/commercial/AGENT_EFFICIENCY_AUDIT.md)
+
+---
+
+## Project maturity
+
+| Component | Status | Notes |
+|---|---|---|
+| Liminal Core | Early-access | Product/research hub |
+| WebSocket backend | Prototype/working | FastAPI, JWT, Prometheus, tests |
+| Liminal Pulse | Prototype direction | Flutter app direction |
+| LTP | Active technical project | Trace continuity and deterministic replay |
+| CML | Active technical project | Causal audit layer |
+| CaPU | Spec-first runtime | Permission-first safe action lifecycle |
+| LiminalDB | Active Rust project | Reactive state database |
+| DAO_lim | Active infra project | AI backend routing and fallback |
+| LiminalQAengineer | Product/prototype direction | QA observability and risk scoring |
+
+---
+
 # 🌌 LIMINAL — путь к внутренней мудрости
 
 **LIMINAL** — это гибридная AI-платформа для осознанных переходов, внутренней зрелости и развития автономии.
 
 ## 📚 Оглавление
 - [📘 Документация проекта](docs/README.md)
+- [🌍 Ecosystem map](ECOSYSTEM.md)
+- [🔍 Project status](STATUS.md)
+- [🧭 Community roadmap](COMMUNITY_ROADMAP.md)
+- [💼 Agent Efficiency Audit](docs/commercial/AGENT_EFFICIENCY_AUDIT.md)
 - [✨ Что делает LIMINAL](#-что-делает-liminal)
 - [🧠 Архитектура](#-архитектура)
 - [🔍 Статус](#-статус)
@@ -35,6 +102,8 @@
 
 Проект находится на стадии early-access.
 Открыта форма сбора интереса и обратной связи: [https://safal207.github.io/Liminal](https://safal207.github.io/Liminal)
+
+См. также: [STATUS.md](STATUS.md).
 
 ## 🩺 Проверка здоровья (health/readiness)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,85 @@
+# Liminal Status
+
+This file gives an honest status snapshot of the Liminal root project and the surrounding ecosystem.
+
+---
+
+## What is ready
+
+- Documentation structure for the root project
+- WebSocket backend prototype
+- JWT authentication for WebSocket
+- Prometheus metrics endpoint
+- DoS connection limits
+- Health/readiness check documentation
+- Neo4j integration prototype
+- Docker infrastructure direction
+- Flutter client direction
+- Thyroid Emotional Memory System prototype
+- Related repositories for traces, causal memory, safe runtime, reactive storage, routing, and QA intelligence
+
+---
+
+## What is experimental
+
+- Human transition support
+- Inner Council experience
+- Biometric and emotional state modeling
+- Maturity Engine
+- Consciousness-oriented UX
+- Multi-agent continuity
+- Cross-repository Liminal Stack integration
+- Commercial audit workflow
+
+---
+
+## What is not production-ready yet
+
+- Unified deployment for the whole ecosystem
+- Public SaaS product
+- Stable SDK
+- Complete public API documentation
+- Multi-tenant enterprise version
+- Full security audit
+- Commercial onboarding flow
+- Single reproducible end-to-end demo across LTP, CML, CaPU, LiminalDB, and DAO_lim
+
+---
+
+## Current focus
+
+1. Make the ecosystem understandable.
+2. Stabilize root documentation.
+3. Connect related repositories.
+4. Prepare community issues.
+5. Build one sharp commercial demo.
+6. Avoid creating new names before the current map is clear.
+
+---
+
+## Maturity table
+
+| Component | Status | Notes |
+|---|---|---|
+| Liminal Core | Early-access | Product/research hub |
+| WebSocket backend | Prototype/working | FastAPI, JWT, Prometheus, tests |
+| Liminal Pulse | Prototype direction | Flutter app direction |
+| LTP | Active technical project | Trace continuity and deterministic replay |
+| CML | Active technical project | Causal audit layer |
+| CaPU | Spec-first runtime | Permission-first safe action lifecycle |
+| LiminalDB | Active Rust project | Reactive state database |
+| DAO_lim | Active infra project | AI backend routing and fallback |
+| LiminalQAengineer | Product/prototype direction | QA observability and risk scoring |
+
+---
+
+## Near-term definition of done
+
+Liminal becomes externally understandable when a new visitor can answer these questions in under five minutes:
+
+1. What is Liminal?
+2. Which repository should I open first?
+3. What is working now?
+4. What is experimental?
+5. What can I contribute to?
+6. What could become the first commercial offer?

--- a/docs/commercial/AGENT_EFFICIENCY_AUDIT.md
+++ b/docs/commercial/AGENT_EFFICIENCY_AUDIT.md
@@ -1,0 +1,140 @@
+# Liminal Agent Efficiency Audit
+
+**Liminal Agent Efficiency Audit** is the first practical commercial entry point for the Liminal ecosystem.
+
+It helps teams find where AI-agent workflows lose context, money, safety, and auditability.
+
+---
+
+## Problem
+
+AI-agent systems can appear functional while hiding deep operational problems:
+
+- context is lost between steps
+- outputs cannot be deterministically replayed
+- actions happen without durable permission chains
+- logs show events but not responsibility
+- routing decisions waste money
+- safety failures are discovered too late
+- flaky tests block delivery
+- compliance evidence is incomplete
+
+Traditional logs answer: **what happened?**
+
+Liminal asks deeper questions:
+
+- Why was this action allowed?
+- Which trace proves it?
+- Which permission chain supports it?
+- Can we replay the decision?
+- Where did drift begin?
+- What should have been blocked, held, or audited?
+
+---
+
+## What we audit
+
+1. **Trace continuity**
+   - Missing steps
+   - Broken transitions
+   - Unreplayable actions
+   - Drift between expected and actual behavior
+
+2. **Causal validity**
+   - Missing parent reasons
+   - Missing permission chains
+   - Unsafe SECRET → NET / tool-use chains
+   - Actions that look correct but are causally invalid
+
+3. **Execution safety**
+   - Execute-before-commit patterns
+   - Side effects without durable state
+   - Missing hold/reject/block decisions
+   - Weak retry and timeout behavior
+
+4. **Routing efficiency**
+   - Overpriced model usage
+   - Poor fallback behavior
+   - No latency/cost-aware routing
+   - Provider failure handling gaps
+
+5. **QA intelligence**
+   - Flaky tests
+   - Unstable pipelines
+   - Weak merge gates
+   - Missing risk scoring
+
+---
+
+## Liminal Stack components
+
+| Component | Role in the audit |
+|---|---|
+| LTP | Trace replay and continuity inspection |
+| CML | Causal memory and permission validation |
+| CaPU | Safe action lifecycle: Gate → Incubate → Commit → Execute |
+| LiminalDB | Reactive state and audit storage |
+| DAO_lim | Intent-aware routing and fallback analysis |
+| LiminalQAengineer | Test risk, flake risk, and QA observability |
+
+---
+
+## Audit output
+
+The audit should produce:
+
+- risk map
+- trace continuity report
+- causal validity report
+- unsafe action examples
+- routing waste analysis
+- QA risk summary
+- recommended fixes
+- demo-ready before/after story
+
+---
+
+## Target users
+
+- AI startups
+- agentic workflow teams
+- fintech teams
+- QA automation teams
+- LLM infrastructure teams
+- compliance-heavy companies
+- teams using multi-step AI agents in production or near-production environments
+
+---
+
+## Offer
+
+> We audit your AI-agent workflow and show where it loses context, money, safety, and auditability.
+
+Russian version:
+
+> Мы проверяем ваш AI-agent pipeline и показываем, где он теряет контекст, деньги, безопасность и доказуемость.
+
+---
+
+## Demo story
+
+A simple demo should show:
+
+1. An agent performs a multi-step task.
+2. The output looks acceptable.
+3. LTP shows trace drift or missing continuity.
+4. CML shows a missing reason or permission chain.
+5. CaPU shows the action should have been held or blocked.
+6. Liminal audit report explains what happened and how to fix it.
+
+---
+
+## What this is not
+
+This is not a generic AI consulting package.
+
+This is not prompt engineering.
+
+This is not just observability.
+
+This is a focused audit of agent continuity, causal validity, safe execution, routing efficiency, and QA reliability.


### PR DESCRIPTION
## Summary

This PR turns the root Liminal repository into a clearer canonical entry point for the ecosystem.

### Added

- `ECOSYSTEM.md` — map of the Liminal ecosystem and related repositories
- `STATUS.md` — honest maturity/status overview
- `COMMUNITY_ROADMAP.md` — contributor-facing roadmap
- `docs/commercial/AGENT_EFFICIENCY_AUDIT.md` — first commercial entry point

### Updated

- `README.md` now starts with a clearer positioning:
  - continuity layer for human and AI transitions
  - choose-your-path section
  - ecosystem/status/roadmap links
  - project maturity table

Existing health/readiness notes and proprietary license section were preserved.

## Intent

Make Liminal understandable to new visitors, contributors, researchers, and potential commercial users without requiring a long private explanation.