### PR TITLE
examples: add agent audit demo artifacts

### DIFF
--- a/docs/demo/AGENT_AUDIT_DEMO_STORY.md
+++ b/docs/demo/AGENT_AUDIT_DEMO_STORY.md
@@ -12,6 +12,8 @@ It is designed to be understandable in three minutes by:
 - QA / platform teams
 - compliance-heavy teams
 
+Minimal reproducible artifact: [`examples/agent_audit_demo`](../../examples/agent_audit_demo/README.md).
+
 ---
 
 ## One-line demo
@@ -297,12 +299,13 @@ It shows the difference between:
 
 ---
 
-## Next implementation step
+## Reproducible artifact
 
-Turn this story into a minimal reproducible artifact:
+This story now has a minimal reproducible artifact:
 
 ```text
 examples/agent_audit_demo/
+  README.md
   trace.jsonl
   cml_records.json
   capu_decision.json

--- a/examples/agent_audit_demo/README.md
+++ b/examples/agent_audit_demo/README.md
@@ -1,0 +1,102 @@
+# Agent Audit Demo
+
+This example turns the [Agent Audit Demo Story](../../docs/demo/AGENT_AUDIT_DEMO_STORY.md) into a minimal reproducible artifact.
+
+The demo shows an AI support agent that produces a helpful-looking output but attempts an external refund action without a valid approval chain.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `trace.jsonl` | Minimal agent trace with five transitions |
+| `cml_records.json` | Causal memory records for each transition |
+| `capu_decision.json` | CaPU HOLD decision for unsafe execution |
+| `audit_report.md` | Human-readable audit report |
+
+---
+
+## What to inspect
+
+### 1. Trace continuity
+
+Open `trace.jsonl` and inspect transition `t5`:
+
+```json
+{"transition_id":"t5","actor":"support_agent","action":"execute_refund","amount":"50 EUR","anchors":[]}
+```
+
+The external refund action has no anchors.
+
+### 2. Causal validity
+
+Open `cml_records.json` and inspect `cml_005`:
+
+```json
+{
+  "transition_id": "t5",
+  "action": "execute_refund",
+  "causal_status": "invalid",
+  "violations": [
+    "MISSING_PARENT",
+    "SCOPE_DENIED",
+    "PERMISSION_CHAIN_MISSING"
+  ]
+}
+```
+
+The previous policy check only supports recommendation and drafting, not execution.
+
+### 3. Safe execution
+
+Open `capu_decision.json`:
+
+```json
+{
+  "decision": "HOLD",
+  "reason_code": "PRECONDITIONS_UNMET"
+}
+```
+
+The refund should be held until human approval and a committed permission record exist.
+
+### 4. Audit output
+
+Open `audit_report.md` to see the human-readable explanation.
+
+---
+
+## Demo narrative
+
+Before Liminal:
+
+```text
+Agent output looks good.
+Refund executed.
+Logs exist.
+No one knows whether the action was actually authorized.
+```
+
+After Liminal:
+
+```text
+Agent output is checked.
+Trace gap is detected.
+Missing permission is detected.
+Execution is held.
+Audit report explains why.
+Human can approve or reject safely.
+```
+
+---
+
+## Next step
+
+A future implementation can add a small script that reads these files and prints the final audit decision.
+
+Suggested command:
+
+```bash
+python examples/agent_audit_demo/run_demo.py
+```

--- a/examples/agent_audit_demo/audit_report.md
+++ b/examples/agent_audit_demo/audit_report.md
@@ -1,0 +1,78 @@
+# Liminal Agent Audit Report
+
+## Demo
+
+`agent_audit_demo`
+
+## Summary
+
+The support agent produced a helpful-looking customer response, but attempted an external refund action without a valid approval chain.
+
+## Risk
+
+**High** — external side effect without durable permission.
+
+## Finding 1 — Trace continuity gap
+
+- Transition: `t5`
+- Action: `execute_refund`
+- Amount: `50 EUR`
+- Problem: no declared anchors
+- LTP reason: `NO_ANCHORS_DECLARED`
+
+The refund action cannot be safely replayed as a justified continuation of the trace.
+
+## Finding 2 — Missing causal permission
+
+- Transition: `t5`
+- CML status: `invalid`
+- Violations:
+  - `MISSING_PARENT`
+  - `SCOPE_DENIED`
+  - `PERMISSION_CHAIN_MISSING`
+
+The earlier policy check supports a recommendation and draft, but not direct execution.
+
+## Finding 3 — Execution should be held
+
+- CaPU decision: `HOLD`
+- Reason code: `PRECONDITIONS_UNMET`
+
+Required preconditions:
+
+1. human approval
+2. committed permission record
+3. policy anchor
+
+## Recommended fix
+
+- Split recommendation and execution into separate stages.
+- Require human approval before refund execution.
+- Commit approval as a causal permission record.
+- Add LTP anchor declarations for external actions.
+- Add CML causal records for approval and policy source.
+- Route execution through the CaPU lifecycle: `HOLD -> ACCEPT -> COMMIT -> EXECUTE`.
+
+## Before Liminal
+
+```text
+Agent output looks good.
+Refund executed.
+Logs exist.
+No one knows whether the action was actually authorized.
+```
+
+## After Liminal
+
+```text
+Agent output is checked.
+Trace gap is detected.
+Missing permission is detected.
+Execution is held.
+Audit report explains why.
+Human can approve or reject safely.
+```
+
+## Business value
+
+The company avoids unauthorized external action, gains audit evidence, and turns an opaque agent behavior into a controlled workflow.

--- a/examples/agent_audit_demo/capu_decision.json
+++ b/examples/agent_audit_demo/capu_decision.json
@@ -1,0 +1,33 @@
+{
+  "demo": "agent_audit_demo",
+  "component": "CaPU",
+  "pipeline": "Gate -> Incubate -> Commit -> Execute",
+  "target_transition_id": "t5",
+  "action": "execute_refund",
+  "decision": "HOLD",
+  "reason_code": "PRECONDITIONS_UNMET",
+  "required_preconditions": [
+    "human_approval",
+    "committed_permission_record",
+    "policy_anchor"
+  ],
+  "observed_failures": [
+    {
+      "source": "LTP",
+      "reason": "NO_ANCHORS_DECLARED",
+      "message": "External refund execution has no declared anchor to approval or committed permission."
+    },
+    {
+      "source": "CML",
+      "reason": "PERMISSION_CHAIN_MISSING",
+      "message": "Refund action has no durable parent permission and exceeds recommendation scope."
+    }
+  ],
+  "message": "Execution is held until approval and permission record are committed.",
+  "safe_next_steps": [
+    "Request human approval for external refund execution.",
+    "Commit approval as a causal permission record.",
+    "Attach the approval record as an anchor for the refund action.",
+    "Re-run the Gate -> Incubate -> Commit -> Execute lifecycle."
+  ]
+}

--- a/examples/agent_audit_demo/cml_records.json
+++ b/examples/agent_audit_demo/cml_records.json
@@ -1,0 +1,60 @@
+{
+  "demo": "agent_audit_demo",
+  "records": [
+    {
+      "record_id": "cml_001",
+      "transition_id": "t1",
+      "actor": "support_agent",
+      "action": "read_incident_notes",
+      "causal_status": "valid",
+      "parents": [],
+      "permissions": ["read_ticket"],
+      "reason": "Agent is allowed to read assigned support ticket notes."
+    },
+    {
+      "record_id": "cml_002",
+      "transition_id": "t2",
+      "actor": "support_agent",
+      "action": "check_refund_policy",
+      "causal_status": "valid",
+      "parents": ["cml_001"],
+      "permissions": ["read_policy"],
+      "reason": "Agent is allowed to inspect refund policy for recommendation."
+    },
+    {
+      "record_id": "cml_003",
+      "transition_id": "t3",
+      "actor": "support_agent",
+      "action": "infer_compensation_allowed",
+      "causal_status": "valid_for_recommendation_only",
+      "parents": ["cml_002"],
+      "permissions": ["recommend_compensation"],
+      "reason": "Policy excerpt supports a recommendation, not direct execution."
+    },
+    {
+      "record_id": "cml_004",
+      "transition_id": "t4",
+      "actor": "support_agent",
+      "action": "draft_external_email",
+      "causal_status": "valid_for_draft_only",
+      "parents": ["cml_003"],
+      "permissions": ["draft_email"],
+      "reason": "Agent may draft customer-facing text but must not send or execute refund without approval."
+    },
+    {
+      "record_id": "cml_005",
+      "transition_id": "t5",
+      "actor": "support_agent",
+      "action": "execute_refund",
+      "causal_status": "invalid",
+      "parents": [],
+      "permissions": [],
+      "violations": [
+        "MISSING_PARENT",
+        "SCOPE_DENIED",
+        "PERMISSION_CHAIN_MISSING"
+      ],
+      "reason": "Refund execution has no durable parent permission and exceeds recommendation scope."
+    }
+  ]
+}

--- a/examples/agent_audit_demo/trace.jsonl
+++ b/examples/agent_audit_demo/trace.jsonl
@@ -1,0 +1,5 @@
+{"transition_id":"t1","actor":"support_agent","action":"read_incident_notes","resource":"ticket_481","result":"incident_summary_created","timestamp":"2026-05-11T13:00:00Z"}
+{"transition_id":"t2","actor":"support_agent","action":"check_refund_policy","resource":"refund_policy_v3","result":"policy_excerpt_found","timestamp":"2026-05-11T13:00:03Z"}
+{"transition_id":"t3","actor":"support_agent","action":"infer_compensation_allowed","claim":"customer is eligible for compensation","anchors":["t2"],"timestamp":"2026-05-11T13:00:06Z"}
+{"transition_id":"t4","actor":"support_agent","action":"draft_external_email","claim":"we will compensate you","anchors":["t3"],"timestamp":"2026-05-11T13:00:09Z"}
+{"transition_id":"t5","actor":"support_agent","action":"execute_refund","amount":"50 EUR","anchors":[],"timestamp":"2026-05-11T13:00:12Z"}


### PR DESCRIPTION
## Summary

Adds a minimal reproducible artifact for the Agent Audit Demo Story.

### Added

- `examples/agent_audit_demo/README.md`
- `examples/agent_audit_demo/trace.jsonl`
- `examples/agent_audit_demo/cml_records.json`
- `examples/agent_audit_demo/capu_decision.json`
- `examples/agent_audit_demo/audit_report.md`

### Updated

- `docs/demo/AGENT_AUDIT_DEMO_STORY.md` now links to the example artifact.

## Intent

Turn the Liminal Stack demo from a story into inspectable files that show:

- trace continuity gap
- missing causal permission
- CaPU HOLD decision
- human-readable audit report

Closes #70.