### PR TITLE
style: format integrated agent audit demo runner

### DIFF
--- a/examples/agent_audit_demo/run_demo.py
+++ b/examples/agent_audit_demo/run_demo.py
@@ -323,9 +323,7 @@ def run_integrated() -> int:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Run the Liminal agent audit demo."
-    )
+    parser = argparse.ArgumentParser(description="Run the Liminal agent audit demo.")
     parser.add_argument(
         "--mode",
         choices=("static", "integrated"),


### PR DESCRIPTION
## Summary

Fixes the failed Black formatting check after PR #84.

## Root cause

`LIMINAL Production Deployment / quality-checks` failed at:

```text
Code formatting check (Black)
```

Black wanted to reformat the `argparse.ArgumentParser(...)` call in:

```text
examples/agent_audit_demo/run_demo.py
```

## Fix

Applies the exact Black diff:

```python
parser = argparse.ArgumentParser(description="Run the Liminal agent audit demo.")
```

## Validation target

This should unblock:

```text
LIMINAL Production Deployment / quality-checks / Code formatting check (Black)
```