### PR TITLE
ci: smoke test agent audit demo runner modes

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -56,6 +56,12 @@ jobs:
       run: |
         mypy src tests || true
 
+    - name: Smoke test agent audit demo runner
+      run: |
+        python examples/agent_audit_demo/run_demo.py
+        python examples/agent_audit_demo/run_demo.py --mode static
+        python examples/agent_audit_demo/run_demo.py --mode integrated
+
     - name: Run unit tests (skip integration)
       run: |
         export PYTHONPATH="${PWD}:${PYTHONPATH}"


### PR DESCRIPTION
## Summary

Adds a lightweight Python CI smoke check for the agent audit demo runner.

## Added

Python CI now runs:

```bash
python examples/agent_audit_demo/run_demo.py
python examples/agent_audit_demo/run_demo.py --mode static
python examples/agent_audit_demo/run_demo.py --mode integrated
```

## Why

The demo runner is now a public entry point for the Liminal Agent Audit Demo. CI should catch regressions where the CLI stops working.

## Notes

- This does not require external LTP/CML/CaPU tools.
- Integrated mode uses the existing fallback behavior when env command templates are not configured.
- This does not change backend pytest structure.

Closes #88.