### PR TITLE
perf/arch: performance and architecture improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@ __pycache__/
 *.so
 .venv/
 venv/
+.env
 .env.local
 .env.production
+backend/.env
 backend/.env.local
 backend/.env.production
 pip-wheel-metadata/

--- a/BLUE_AUDIT_REPORT.md
+++ b/BLUE_AUDIT_REPORT.md
@@ -1,0 +1,343 @@
+# 🔵 Blue Bug Audit — Liminal
+
+**Дата:** 2026-05-17
+**Ветка:** `claude/blue-audit-bugs-Ucal8`
+**Скоуп:** Python (backend, src, auth), JavaScript/TypeScript (frontend, webapp), Go (go_ws_relay), Haskell (rinse), конфигурация (Docker, .env, k8s, nginx, CI)
+
+Этот отчёт — реальные баги, найденные в текущем коде. Каждый пункт привязан к `file:line` с фрагментом. Сортировка — по приоритету (Critical → Low).
+
+---
+
+## 🚨 CRITICAL (требуется немедленный фикс)
+
+### C-1. Auth bypass: `DummyCryptContext.verify` всегда возвращает `True`
+**Файл:** `backend/auth/jwt_utils.py:31-43`
+
+```python
+class DummyCryptContext:
+    def verify(self, plain_password, hashed_password):
+        # В тестовом режиме всегда возвращаем True
+        return True
+```
+
+Fallback срабатывает, если `passlib`/`bcrypt` не импортируется (`ImportError | AttributeError`). В этом режиме `authenticate_user(...)` принимает **любой пароль** для существующего пользователя. На любом окружении, где bcrypt не собрался (Alpine, ARM, поломанный wheel) — это рабочий бэкдор. Решение: при провале импорта бросать на старте, а не подсовывать «no-op» проверку.
+
+### C-2. JWT secret и пароль Neo4j захардкожены как дефолты на проде
+**Файлы:** `backend/config.py:29`, `backend/config.py:36-38`, `backend/config.py:58`, `backend/config.py:61-63`
+
+```python
+neo4j_password: str = "NewStrongPass123!"
+jwt_secret_key: str = "test-jwt-secret-key-for-local-development-only"
+...
+"neo4j_password": os.getenv("NEO4J_PASSWORD", "NewStrongPass123!"),
+"jwt_secret_key": os.getenv("JWT_SECRET_KEY", "test-jwt-secret-key-for-local-development-only"),
+```
+
+При забытой переменной окружения сервис стартует с предсказуемым секретом → подделка JWT, доступ к Neo4j. Решение: `raise RuntimeError` при `ENV in {"production","staging"}` и пустых креденшелах.
+
+### C-3. CORS `allow_origins=["*"]` + `allow_credentials=True` на 4 сервисах
+**Файлы:**
+- `backend/api.py:202-208`
+- `backend/emotime/api_simple.py:27-32`
+- `backend/production/rgl_core_service.py:184-190`
+- `backend/ml/xai_main.py:67-73`
+
+Комбинация `*` + credentials — нарушение CORS-спецификации, открывает credential theft / CSRF с любого внешнего сайта (браузер всё-таки запрещает буквальный `*`+credentials, но FastAPI это часто разворачивает в эхо-Origin — фактический результат: разрешено всё). Решение: задать конкретный whitelist через настройки.
+
+### C-4. Hardcoded пароли в `docker-compose.production.yml`
+**Файл:** `backend/production/docker-compose.production.yml:15, 88, 125`
+
+```yaml
+NEO4J_PASSWORD=rgl_production_password
+NEO4J_AUTH=neo4j/rgl_production_password
+GF_SECURITY_ADMIN_PASSWORD=rgl_admin_password
+```
+
+Прод-креды закоммичены в репозиторий. Должны идти через секреты Docker/K8s (`secrets:`).
+
+### C-5. Файл `.env` отслеживается git'ом
+**Файл:** `.env` (107 строк), хотя в `.gitignore` указаны только `.env.local` и `.env.production`.
+
+```
+JWT_SECRET=your-super-secret-jwt-key-here
+OPENAI_API_KEY=sk-your-openai-api-key-here
+GRAFANA_ADMIN_PASSWORD=admin
+DEBUG=true
+DATABASE_URL=postgresql://user:password@localhost:5432/resonance_liminal
+```
+
+Сейчас в файле плейсхолдеры, но любой `git add .` уже добавит реальные креды — слот в репозитории для них существует. Решение: `git rm --cached .env`, перенести в `.env.example`, добавить `.env` в `.gitignore`.
+
+### C-6. Hardcoded Neo4j-пароль в Go-сервисе
+**Файл:** `go_ws_relay/neo4j_api.go:14-17`
+
+```go
+const (
+    neo4jURI      = "neo4j://localhost:7687"
+    neo4jUsername = "neo4j"
+    neo4jPassword = "NewStrongPass123!"
+)
+```
+
+Должно читаться из переменных окружения. `const` ещё и попадает в бинарь — выдать его уже значит выдать пароль.
+
+---
+
+## 🔴 HIGH
+
+### H-1. Resource leak: `traceback.print_exc(file=open(OUTPUT_FILE, "a"))`
+**Файл:** `backend/file_output_philosophy.py:115, 161, 203, 250, 280`
+
+`open()` без `with` и без `.close()` — каждый вызов оставляет дескриптор. Заменить на:
+```python
+with open(OUTPUT_FILE, "a") as f:
+    traceback.print_exc(file=f)
+```
+
+### H-2. Unsafe `pickle.load` для ML-моделей
+**Файл:** `backend/ml_pipeline_enhanced.py:203-212`
+
+```python
+def load(self, path: str) -> bool:
+    with open(path, "rb") as f:
+        self.model = pickle.load(f)
+```
+
+Если путь к файлу хоть как-то контролируется снаружи (configs, скачанные артефакты из MLflow/MinIO) — RCE. Минимум: подписать артефакт (HMAC), верифицировать перед `pickle.load`. Лучше: `joblib` + sklearn-only / ONNX.
+
+### H-3. Тестовые пользователи `testpass`/`admin123` зашиты в код
+**Файл:** `backend/auth/jwt_utils.py:181-197`
+
+```python
+fake_users_db = {
+    "testuser": {"hashed_password": jwt_manager.get_password_hash("testpass"), ...},
+    "admin":    {"hashed_password": jwt_manager.get_password_hash("admin123"), ...},
+}
+```
+
+Эти учётки активны на любом окружении, импортирующем `jwt_utils`, в т.ч. через `/auth/token` в проде. Решение: убрать из модуля, оставить только в фикстурах тестов.
+
+### H-4. Reflected XSS через `innerHTML` со значениями из CONFIG/state
+**Файлы:**
+- `frontend/consciousness_map/js/state-controller.js:189`
+- `frontend/consciousness_map/js/graph-renderer.js:311`
+- `frontend/consciousness_map/js/main.js:52, 172, 255`
+
+```javascript
+insightPanel.innerHTML = `
+  <h4>Утренний путь: ${stateInfo.label}</h4>
+  <p>${stateInfo.description}</p>
+`;
+```
+
+`stateInfo.*` приходит из объединения CONFIG и backend-данных (Neo4j). Если оттуда прилетит `<img onerror=...>` — выполнение в DOM. Решение: `textContent`, или `createElement` + `appendChild`, или эскейпить через шаблонизатор.
+
+### H-5. Goroutine без `context.Context` — утечка по соединениям
+**Файл:** `go_ws_relay/graphql/subscriptions.go:194-210`
+
+```go
+go func() {
+    ticker := time.NewTicker(pingPeriod)
+    defer ticker.Stop()
+    defer conn.Close()
+    for {
+        select {
+        case <-ticker.C:
+            // нет ветки <-ctx.Done()
+        }
+    }
+}()
+```
+
+При обрыве WS-клиента goroutine продолжает тикать, пока `conn.WriteMessage` не упадёт сам. Плюс **двойной `defer conn.Close()`** (другая goroutine рядом тоже закрывает) — гонка/паника на втором закрытии. Решение: пробросить `ctx`, `select { case <-ctx.Done(): return; case <-ticker.C: ... }`, и закрывать соединение в одном месте.
+
+### H-6. `useEffect(load, [])` со внешней зависимостью
+**Файл:** `webapp/src/app/progress/page.tsx:84`
+
+```tsx
+useEffect(() => { load(days); }, []);
+```
+
+Здесь автор «спас» баг ручным вызовом `load(d)` в `onClick`, но lint-правило `react-hooks/exhaustive-deps` всё равно отключено молча. Любой следующий разработчик, кто перестанет вызывать `load` вручную, получит стейл-данные. Поставить `[days]` или вынести во `useCallback`.
+
+### H-7. Partial functions `head`/`(!!)` без проверок
+**Файл:** `rinse/src/ResonanceGrafting.hs:134, 224`, `rinse/src/DuneField.hs:179`, `rinse/src/RINSE.hs:40`
+
+```haskell
+selectedPaths = map (allPaths !!) selectedIndices
+...
+TYOK.etTimestamp (head states)
+```
+
+`!!` и `head` падают рантайм-эксепшеном на пустом/коротком списке. Использовать `safe`/`listToMaybe`/`Data.Maybe.fromMaybe`.
+
+### H-8. Bare `except:` глотает `KeyboardInterrupt`/`SystemExit`
+**Файлы (выборка):** `backend/emotime/security/auth.py:279`, `backend/security_enhanced.py:583`, `backend/emotime/metrics_integration.py:30, 63`, `src/liminal/reality_web_neo4j.py:425`, `backend/quantum/rgl_quantum_integration.py:157`, `backend/bci/mindbridge_direct.py:148, 853`, `backend/emotime/utils.py:23, 32, 52`, `backend/performance/*.py` — всего ~20 мест.
+
+```python
+try:
+    payload = jwt.decode(token, ..., options={"verify_exp": False})
+    ...
+except:
+    pass
+```
+
+Особенно опасно в `auth.py:279`: глотает ошибки декодирования JWT при ревокации (см. также **H-9**).
+
+### H-9. Ревокация JWT с `verify_exp=False`
+**Файл:** `backend/emotime/security/auth.py:270-280`
+
+```python
+payload = jwt.decode(token, self.secret_key, algorithms=[self.algorithm],
+                     options={"verify_exp": False})
+```
+
+В контексте ревокации это нормально (мы и хотим вытащить `sid` даже из протухшего токена), **но** при этом `audience`/`issuer` не проверяются → можно отозвать сессию по чужому валидному JWT с другим `aud`. Добавить `audience=…, issuer=…`.
+
+### H-10. Type assertion'ы в Go без `ok`
+**Файл:** `go_ws_relay/neo4j_api.go:140-189`
+
+```go
+ID:    id.(string),
+State: state.(string),
+```
+
+Если Neo4j вернёт `nil` или другой тип — паника всего сервиса. `v, ok := x.(string); if !ok { ... }`.
+
+### H-11. setInterval без clearInterval — утечка таймеров в SPA
+**Файл:** `frontend/consciousness_map/js/main.js:59-71, 214`
+
+```javascript
+setInterval(() => { ... }, 1000);
+app.emotimePollInterval = setInterval(pollEmotimeStatus, EMOTIME_POLL_MS);
+```
+
+При навигации (или повторной инициализации) предыдущий таймер продолжает работать; за день вкладки наберётся горка событий и сетевых запросов.
+
+### H-12. Hardcoded test-креды в docker-compose.local.yml / docker-compose.ml.yml
+**Файлы:** `docker-compose.local.yml:12, 29, 40, 83`, `docker-compose.ml.yml:95-96`, `docker-compose.ml-production.yml:65-66`
+
+```yaml
+POSTGRES_PASSWORD=test_postgres_password_123
+NEO4J_AUTH=neo4j/test_neo4j_password_123
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+```
+
+`docker-compose.ml-production.yml` — это уже не «test», но пароли всё равно слабые и в репо.
+
+---
+
+## 🟡 MEDIUM
+
+### M-1. Отсутствует `_track_operation()` в одном из методов Neo4jClient
+**Файл:** `backend/infrastructure/neo4j/client.py:145`
+
+`create_memory_fragment_node` не оборачивается в `with self._track_operation(...)` в отличие от соседних методов — операции этого метода не попадают в метрики/локи. Расхождение поведения по записи.
+
+### M-2. Division-by-zero в test-раннере
+**Файл:** `test_runner.py:263, 278`
+
+```python
+print(f"Success Rate: {(passed_tests/total_tests)*100:.1f}%")
+```
+
+При пустом списке упадёт `ZeroDivisionError` — портит CI-отчёт. То же в `backend/test_integration_simple.py:265`.
+
+### M-3. Map гонка в WS-relay
+**Файл:** `go_ws_relay/main.go:23-24` и места, где `clients` map читают без `clientsMutex`.
+
+Несинхронизированный доступ к map в Go — undefined behavior, обычно `concurrent map read and map write` → паника.
+
+### M-4. `topic, _ := request["topic"].(string)` — пустая строка как валидный topic
+**Файл:** `go_ws_relay/graphql/subscriptions.go:162`
+
+Игнор `ok` приводит к тому, что неверный тип превратится в `""`, и подписка пройдёт на «пустой» топик.
+
+### M-5. `subprocess.run(["chcp", "65001"], shell=True)`
+**Файл:** `backend/emotime/utils.py:22`
+
+`shell=True` со списком — Python берёт **только первый элемент** (`"chcp"`), остальное игнорится, при этом запускается shell. Это и не работает как задумано, и расширяет поверхность атаки на ровном месте. Убрать `shell=True`.
+
+### M-6. MD5 для cache-key
+**Файл:** `backend/database_optimization.py`
+
+```python
+return hashlib.md5(query_str.encode()).hexdigest()
+```
+
+Технически не криптоиспользование, но MD5 нагружает сэндбоксы/FIPS-режимы (`hashlib.md5(..., usedforsecurity=False)` или blake2). На некоторых сборках упадёт.
+
+### M-7. `datetime.utcnow()` в 81 месте
+В Python 3.12+ deprecated (DeprecationWarning) и в 3.13 удаление приближается. Менять на `datetime.now(timezone.utc)`.
+
+### M-8. Двойной `defer conn.Close()` в WS-relay
+См. **H-5** — `subscriptions.go:138` и `:198` оба `defer conn.Close()`. Один из них вернёт ошибку «use of closed network connection».
+
+### M-9. Nullable-узлы в frontend graph
+**Файл:** `frontend/consciousness_map/js/data-service.js:356-358`
+
+```javascript
+const source = this.nodes.find(node => node.id === transition.from_id);
+const target = this.nodes.find(node => node.id === transition.to_id);
+return { ...target, ... };
+```
+
+Если узел не найден, `target === undefined` — спред `...undefined` ок, но дальнейшие `.x` упадут.
+
+### M-10. Хардкод тестовых креденшелов в GitHub Actions
+**Файл:** `.github/workflows/production-deployment.yml:147, 172, 182, 192`
+
+```yaml
+NEO4J_AUTH: neo4j/testpassword
+NEO4J_PASSWORD: testpassword
+```
+
+Для CI-теста ок, но соблазн «временно» так же делать в env-job — фиксируется как анти-паттерн.
+
+---
+
+## 🟢 LOW
+
+### L-1. `HS256` для long-lived токенов
+`backend/emotime/security/auth.py:75`: комментарий «Use RS256 in production» — но код всё равно ставит `HS256`. Рекомендуется ассиметричная подпись для refresh/websocket токенов длиной в часы/дни.
+
+### L-2. Refresh-токен подписан тем же секретом, что и access
+`backend/auth/jwt_utils.py:262-274`. При утечке секретa access → утечка refresh. В идеале — отдельный ключ для refresh.
+
+### L-3. Promise-rejection без `.catch` при старте
+`frontend/consciousness_map/js/main.js:85-91` — `loadDataFromNeo4j()` запускается без `.catch`, что приводит к `Uncaught (in promise)`. Сейчас вроде `.catch` есть, но проверить полный путь.
+
+### L-4. Пустой `scopes`/`roles` в `/me`
+`backend/auth/auth_router.py:122-132` отдаёт `scopes` и `roles`, которые в `fake_users_db` не определены — `KeyError` маскируется `.get(..., [])`, но клиент получает фиктивные значения.
+
+### L-5. `lru_cache` на `get_jwt_manager()` + чтение `Settings`
+`backend/auth/jwt_utils.py:172-179` — секрет читается один раз; ротация ключа без рестарта невозможна.
+
+---
+
+## Сводка
+
+| Категория | Critical | High | Medium | Low | Всего |
+|---|---|---|---|---|---|
+| Auth/Crypto | 2 | 2 | 1 | 2 | 7 |
+| Web/CORS/XSS | 1 | 1 | 1 | 1 | 4 |
+| Secrets в репозитории | 3 | 1 | 1 | 0 | 5 |
+| Resource leak / Race | 0 | 3 | 3 | 0 | 6 |
+| Logic / partial functions | 0 | 2 | 2 | 0 | 4 |
+| Deprecation / стиль | 0 | 0 | 2 | 0 | 2 |
+| **Итого** | **6** | **12** | **10** | **5** | **33** |
+
+## Приоритет фиксов (mini-plan)
+
+1. **C-1**: убрать `DummyCryptContext` (fail-fast на старте).
+2. **C-2/C-4/C-6**: вынести все пароли в секреты, требовать env-vars, упасть в проде без них.
+3. **C-3**: CORS whitelist.
+4. **C-5**: `git rm --cached .env`, обновить `.gitignore`, добавить `.env.example`.
+5. **H-1/H-2/H-3/H-5/H-10**: пакет «руки» — context managers, signed pickle/joblib, удалить `fake_users_db`, `ctx` в goroutine, `, ok` в type assertions.
+6. **H-4/H-11/M-9**: фронтовая санитизация + cleanup таймеров.
+7. **H-7/H-8/M-2/M-4/M-8**: «строгие проверки» — partial functions, bare `except`, division-by-zero, ok-checks.
+
+---
+
+_Сгенерировано: автоматический Blue-аудит, ветка `claude/blue-audit-bugs-Ucal8`._

--- a/backend/api.py
+++ b/backend/api.py
@@ -199,7 +199,11 @@ static_dir = os.path.join(os.path.dirname(__file__), "static")
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 # Настройка CORS
-_cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
+_cors_origins = [
+    o.strip()
+    for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,

--- a/backend/api.py
+++ b/backend/api.py
@@ -199,12 +199,13 @@ static_dir = os.path.join(os.path.dirname(__file__), "static")
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 # Настройка CORS
+_cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Настройка метрик Prometheus

--- a/backend/api.py
+++ b/backend/api.py
@@ -71,7 +71,7 @@ except ImportError as e:
 
 settings = get_settings()
 
-print("DEBUG: Before ml_features import")
+logger.debug("Before ml_features import")
 try:
     from backend.ml_features import (
         extract_traffic_features,
@@ -85,9 +85,9 @@ try:
     )
 
     ML_ENABLED = settings.integrations.ml_enabled
-    print(f"DEBUG: Successfully imported ml_features. ML_ENABLED={ML_ENABLED}")
+    logger.debug("Successfully imported ml_features. ML_ENABLED=%s", ML_ENABLED)
 except ImportError as e:
-    print(f"ERROR: Failed to import ml_features: {e}")
+    logger.error("Failed to import ml_features: %s", e)
     ML_ENABLED = False
 
     def extract_user_patterns():
@@ -354,7 +354,13 @@ async def websocket_timeline(websocket: WebSocket, token: str = None):
                 }
             )
 
-            auth_data = await websocket.receive_text()
+            try:
+                auth_data = await asyncio.wait_for(
+                    websocket.receive_text(), timeout=30.0
+                )
+            except asyncio.TimeoutError:
+                await connection_manager.reject_connection(websocket, "Auth timeout")
+                return
             try:
                 auth_message = json.loads(auth_data)
             except (TypeError, json.JSONDecodeError):

--- a/backend/auth/jwt_utils.py
+++ b/backend/auth/jwt_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 from datetime import datetime, timedelta
 from functools import lru_cache
 from typing import Any, Dict, Optional
@@ -27,20 +28,24 @@ except (ImportError, AttributeError) as e:
     )
     CRYPTO_ENABLED = False
 
-    # Заглушка для CryptContext
-    class DummyCryptContext:
-        def __init__(self, **kwargs):
-            pass
+    # Fail closed: never silently accept all passwords when crypto is unavailable.
+    class _UnavailableCryptContext:
+        def __init__(self, error: Exception) -> None:
+            self._error = error
 
-        def verify(self, plain_password, hashed_password):
-            # В тестовом режиме всегда возвращаем True
-            return True
+        def verify(self, plain_password: str, hashed_password: str) -> bool:
+            raise RuntimeError(
+                "passlib/bcrypt failed to import; password verification is unavailable. "
+                f"Original error: {self._error}. Install with: pip install 'passlib[bcrypt]'"
+            ) from self._error
 
-        def hash(self, password):
-            # В тестовом режиме просто возвращаем хеш-подобную строку
-            return f"$2b$12$DUMMY_HASH_FOR_TESTING_{password[:5]}"
+        def hash(self, password: str) -> str:
+            raise RuntimeError(
+                "passlib/bcrypt failed to import; password hashing is unavailable. "
+                f"Original error: {self._error}. Install with: pip install 'passlib[bcrypt]'"
+            ) from self._error
 
-    pwd_context = DummyCryptContext()
+    pwd_context = _UnavailableCryptContext(e)
 
 logger = logging.getLogger("auth.jwt_utils")
 
@@ -178,23 +183,34 @@ def get_jwt_manager() -> JWTManager:
 
 jwt_manager = get_jwt_manager()
 
-# Временное хранилище пользователей (в продакшене заменить на БД)
-fake_users_db = {
-    "testuser": {
+# In-memory user store populated from environment variables.
+# Replace with a real database backend before production use.
+# Configure users by setting LIMINAL_TEST_USER_PASS and/or LIMINAL_ADMIN_PASS env vars.
+_test_user_pass = os.getenv("LIMINAL_TEST_USER_PASS", "")
+_admin_pass = os.getenv("LIMINAL_ADMIN_PASS", "")
+
+fake_users_db: Dict[str, Any] = {}
+if _test_user_pass:
+    fake_users_db["testuser"] = {
         "user_id": "testuser",
         "username": "testuser",
-        "hashed_password": jwt_manager.get_password_hash("testpass"),
+        "hashed_password": jwt_manager.get_password_hash(_test_user_pass),
         "email": "test@example.com",
         "is_active": True,
-    },
-    "admin": {
+    }
+if _admin_pass:
+    fake_users_db["admin"] = {
         "user_id": "admin",
         "username": "admin",
-        "hashed_password": jwt_manager.get_password_hash("admin123"),
+        "hashed_password": jwt_manager.get_password_hash(_admin_pass),
         "email": "admin@example.com",
         "is_active": True,
-    },
-}
+    }
+if not fake_users_db:
+    logger.warning(
+        "No users configured. Set LIMINAL_TEST_USER_PASS / LIMINAL_ADMIN_PASS env vars "
+        "or replace fake_users_db with a real database backend."
+    )
 
 
 def authenticate_user(username: str, password: str) -> Optional[Dict[str, Any]]:

--- a/backend/config.py
+++ b/backend/config.py
@@ -67,26 +67,31 @@ class Settings(BaseModel):
             == "true",
         }
 
-        # In production, warn if using default secrets (but don't fail startup for CI)
-        if environment != "development":
+        if environment == "production":
             if (
                 env_values["jwt_secret_key"]
                 == "test-jwt-secret-key-for-local-development-only"
             ):
-                import warnings
-
+                raise RuntimeError(
+                    "JWT_SECRET_KEY must be set to a strong random secret in production. "
+                    "Set the JWT_SECRET_KEY environment variable."
+                )
+            if env_values["neo4j_password"] == "NewStrongPass123!":
+                raise RuntimeError(
+                    "NEO4J_PASSWORD must be changed from the default value in production. "
+                    "Set the NEO4J_PASSWORD environment variable."
+                )
+        elif environment not in ("development", "test"):
+            import warnings
+            if env_values["jwt_secret_key"] == "test-jwt-secret-key-for-local-development-only":
                 warnings.warn(
-                    "⚠️  WARNING: Using default JWT_SECRET_KEY in production! "
-                    "Set JWT_SECRET_KEY environment variable immediately!",
+                    "Using default JWT_SECRET_KEY. Set JWT_SECRET_KEY before going to production.",
                     UserWarning,
                     stacklevel=2,
                 )
             if env_values["neo4j_password"] == "NewStrongPass123!":
-                import warnings
-
                 warnings.warn(
-                    "⚠️  WARNING: Using default NEO4J_PASSWORD in production! "
-                    "Set NEO4J_PASSWORD environment variable immediately!",
+                    "Using default NEO4J_PASSWORD. Set NEO4J_PASSWORD before going to production.",
                     UserWarning,
                     stacklevel=2,
                 )

--- a/backend/config.py
+++ b/backend/config.py
@@ -83,7 +83,11 @@ class Settings(BaseModel):
                 )
         elif environment not in ("development", "test"):
             import warnings
-            if env_values["jwt_secret_key"] == "test-jwt-secret-key-for-local-development-only":
+
+            if (
+                env_values["jwt_secret_key"]
+                == "test-jwt-secret-key-for-local-development-only"
+            ):
                 warnings.warn(
                     "Using default JWT_SECRET_KEY. Set JWT_SECRET_KEY before going to production.",
                     UserWarning,

--- a/backend/database_optimization.py
+++ b/backend/database_optimization.py
@@ -18,7 +18,7 @@ import logging
 import time
 import uuid
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -352,11 +352,15 @@ class ConnectionPool:
         }
 
 
+_QUERY_CACHE_MAX_SIZE = 1000
+_SLOW_QUERY_MAX_SIZE = 1000
+
+
 class QueryOptimizer:
     """Query optimization and caching system."""
 
     def __init__(self):
-        self.query_cache: Dict[str, Any] = {}
+        self.query_cache: OrderedDict = OrderedDict()
         self.query_stats: Dict[str, Dict] = defaultdict(
             lambda: {
                 "count": 0,
@@ -384,11 +388,11 @@ class QueryOptimizer:
         if self._should_cache_query(query) and query_hash in self.query_cache:
             cache_entry = self.query_cache[query_hash]
             if time.time() - cache_entry["timestamp"] < cache_ttl:
+                self.query_cache.move_to_end(query_hash)
                 self.cache_hits += 1
                 self._update_cache_hit_rate()
                 return cache_entry["result"]
             else:
-                # Expired cache entry
                 del self.query_cache[query_hash]
 
         # Execute query
@@ -406,6 +410,8 @@ class QueryOptimizer:
                     "result": result,
                     "timestamp": time.time(),
                 }
+                while len(self.query_cache) > _QUERY_CACHE_MAX_SIZE:
+                    self.query_cache.popitem(last=False)
 
             self.cache_misses += 1
             self._update_cache_hit_rate()
@@ -427,9 +433,8 @@ class QueryOptimizer:
                     }
                 )
 
-                # Keep only recent slow queries
-                if len(self.slow_queries) > 100:
-                    self.slow_queries = self.slow_queries[-100:]
+                if len(self.slow_queries) > _SLOW_QUERY_MAX_SIZE:
+                    self.slow_queries = self.slow_queries[-_SLOW_QUERY_MAX_SIZE:]
 
             raise
 

--- a/backend/emotime/api_simple.py
+++ b/backend/emotime/api_simple.py
@@ -24,12 +24,13 @@ app = FastAPI(
     version="1.0.0",
 )
 
+_cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Ð‘ÐµÐ·Ð¾Ð¿Ð°ÑÐ½Ð¾ÑÑ‚ÑŒ

--- a/backend/emotime/api_simple.py
+++ b/backend/emotime/api_simple.py
@@ -24,7 +24,11 @@ app = FastAPI(
     version="1.0.0",
 )
 
-_cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
+_cors_origins = [
+    o.strip()
+    for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,

--- a/backend/emotime/security/auth.py
+++ b/backend/emotime/security/auth.py
@@ -276,7 +276,7 @@ class JWTAuthenticator:
                 session_id = payload.get("sid")
                 if session_id and session_id in self.active_sessions:
                     self.active_sessions[session_id].is_active = False
-            except:
+            except Exception:
                 pass  # Token might be malformed, but still revoke the hash
 
             safe_logger.info("JWT token revoked successfully")

--- a/backend/emotime/utils.py
+++ b/backend/emotime/utils.py
@@ -19,8 +19,8 @@ def setup_encoding():
             try:
                 import subprocess
 
-                subprocess.run(["chcp", "65001"], shell=True, capture_output=True)
-            except:
+                subprocess.run(["chcp", "65001"], capture_output=True)
+            except Exception:
                 pass
 
         # Установка переменных окружения для UTF-8
@@ -29,7 +29,7 @@ def setup_encoding():
         # Попробуем установить системную локаль на UTF-8
         try:
             locale.setlocale(locale.LC_ALL, "")
-        except:
+        except Exception:
             pass
 
         return True
@@ -49,7 +49,7 @@ def safe_print(message: str, fallback_encoding: str = "ascii"):
                 fallback_encoding
             )
             print(safe_message)
-        except:
+        except Exception:
             # Последний fallback: только ASCII символы
             ascii_message = "".join(c if ord(c) < 128 else "?" for c in message)
             print(ascii_message)

--- a/backend/file_output_philosophy.py
+++ b/backend/file_output_philosophy.py
@@ -39,9 +39,12 @@ log_to_file(f"Output file: {OUTPUT_FILE}")
 
 
 def check_neo4j_connection(
-    uri="bolt://localhost:7687", user="neo4j", password="NewStrongPass123!"
+    uri=None, user=None, password=None
 ):
     """Test Neo4j connection and database state"""
+    uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = user or os.getenv("NEO4J_USER", "neo4j")
+    password = password or os.getenv("NEO4J_PASSWORD", "")
 
     log_to_file("\n=== NEO4J CONNECTION TEST ===")
     log_to_file(f"Connecting to: {uri}")
@@ -112,14 +115,18 @@ def check_neo4j_connection(
 
     except Exception as e:
         log_to_file(f"\nERROR: Failed to connect to Neo4j: {str(e)}")
-        traceback.print_exc(file=open(OUTPUT_FILE, "a"))
+        with open(OUTPUT_FILE, "a") as _f:
+            traceback.print_exc(file=_f)
         return False
 
 
 def check_resonance_moments(
-    uri="bolt://localhost:7687", user="neo4j", password="NewStrongPass123!"
+    uri=None, user=None, password=None
 ):
     """Find resonance moments between users"""
+    uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = user or os.getenv("NEO4J_USER", "neo4j")
+    password = password or os.getenv("NEO4J_PASSWORD", "")
 
     log_to_file("\n=== RESONANCE MOMENTS ANALYSIS ===")
 
@@ -158,14 +165,18 @@ def check_resonance_moments(
 
     except Exception as e:
         log_to_file(f"\nERROR: Failed to analyze resonance moments: {str(e)}")
-        traceback.print_exc(file=open(OUTPUT_FILE, "a"))
+        with open(OUTPUT_FILE, "a") as _f:
+            traceback.print_exc(file=_f)
         return False
 
 
 def get_user_timeline(
-    user_id, uri="bolt://localhost:7687", user="neo4j", password="NewStrongPass123!"
+    user_id, uri=None, user=None, password=None
 ):
     """Get timeline for a specific user"""
+    uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = user or os.getenv("NEO4J_USER", "neo4j")
+    password = password or os.getenv("NEO4J_PASSWORD", "")
 
     log_to_file(f"\n=== USER TIMELINE: {user_id} ===")
 
@@ -200,7 +211,8 @@ def get_user_timeline(
 
     except Exception as e:
         log_to_file(f"\nERROR: Failed to get user timeline: {str(e)}")
-        traceback.print_exc(file=open(OUTPUT_FILE, "a"))
+        with open(OUTPUT_FILE, "a") as _f:
+            traceback.print_exc(file=_f)
         return False
 
 
@@ -247,7 +259,8 @@ def check_websocket_relay():
 
     except Exception as e:
         log_to_file(f"ERROR: Failed to connect to WebSocket relay: {str(e)}")
-        traceback.print_exc(file=open(OUTPUT_FILE, "a"))
+        with open(OUTPUT_FILE, "a") as _f:
+            traceback.print_exc(file=_f)
 
 
 def main():
@@ -277,7 +290,8 @@ def main():
 
     except Exception as e:
         log_to_file(f"\nFATAL ERROR: {str(e)}")
-        traceback.print_exc(file=open(OUTPUT_FILE, "a"))
+        with open(OUTPUT_FILE, "a") as _f:
+            traceback.print_exc(file=_f)
 
 
 if __name__ == "__main__":

--- a/backend/file_output_philosophy.py
+++ b/backend/file_output_philosophy.py
@@ -38,9 +38,7 @@ log_to_file(f"Started: {datetime.now().isoformat()}")
 log_to_file(f"Output file: {OUTPUT_FILE}")
 
 
-def check_neo4j_connection(
-    uri=None, user=None, password=None
-):
+def check_neo4j_connection(uri=None, user=None, password=None):
     """Test Neo4j connection and database state"""
     uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
     user = user or os.getenv("NEO4J_USER", "neo4j")
@@ -120,9 +118,7 @@ def check_neo4j_connection(
         return False
 
 
-def check_resonance_moments(
-    uri=None, user=None, password=None
-):
+def check_resonance_moments(uri=None, user=None, password=None):
     """Find resonance moments between users"""
     uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
     user = user or os.getenv("NEO4J_USER", "neo4j")
@@ -170,9 +166,7 @@ def check_resonance_moments(
         return False
 
 
-def get_user_timeline(
-    user_id, uri=None, user=None, password=None
-):
+def get_user_timeline(user_id, uri=None, user=None, password=None):
     """Get timeline for a specific user"""
     uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
     user = user or os.getenv("NEO4J_USER", "neo4j")

--- a/backend/ml/xai_main.py
+++ b/backend/ml/xai_main.py
@@ -64,7 +64,11 @@ app = FastAPI(
 )
 
 # CORS middleware
-_cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
+_cors_origins = [
+    o.strip()
+    for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,

--- a/backend/ml/xai_main.py
+++ b/backend/ml/xai_main.py
@@ -64,12 +64,13 @@ app = FastAPI(
 )
 
 # CORS middleware
+_cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # В продакшене ограничить
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # =============================================================================

--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -13,11 +13,12 @@ import json
 import logging
 import time
 import uuid
+from collections import deque
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Deque, Dict, List, Optional, Union
 
 import structlog
 from prometheus_client import (
@@ -74,9 +75,12 @@ class TraceSpan:
         self.end_time = time.time()
         self.status = status
 
+    _MAX_LOGS_PER_SPAN = 100
+
     def log(self, event: str, **kwargs):
         """Add log entry to span."""
-        self.logs.append({"timestamp": time.time(), "event": event, **kwargs})
+        if len(self.logs) < self._MAX_LOGS_PER_SPAN:
+            self.logs.append({"timestamp": time.time(), "event": event, **kwargs})
 
     def set_tag(self, key: str, value: Any):
         """Set span tag."""
@@ -258,6 +262,9 @@ class PrometheusMetrics:
         )
 
 
+_ACTIVE_SPAN_TTL = 300.0  # seconds before a never-finished span is force-closed
+
+
 class DistributedTracer:
     """Distributed tracing implementation for request tracking."""
 
@@ -292,15 +299,28 @@ class DistributedTracer:
         """Finish a tracing span."""
         span.finish(status)
 
-        # Move from active to completed
         if span.span_id in self.active_spans:
             del self.active_spans[span.span_id]
 
         self.completed_spans.append(span)
 
-        # Maintain memory limit
         if len(self.completed_spans) > self.max_completed_spans:
             self.completed_spans = self.completed_spans[-self.max_completed_spans :]
+
+        self._purge_stale_active_spans()
+
+    def _purge_stale_active_spans(self):
+        """Force-close active spans that have been running too long."""
+        now = time.time()
+        stale = [
+            sid
+            for sid, s in self.active_spans.items()
+            if now - s.start_time > _ACTIVE_SPAN_TTL
+        ]
+        for sid in stale:
+            stale_span = self.active_spans.pop(sid)
+            stale_span.finish("timeout")
+            self.completed_spans.append(stale_span)
 
     @asynccontextmanager
     async def trace(
@@ -541,7 +561,7 @@ class MonitoringService:
         self.tracer = DistributedTracer()
         self.health_monitor = HealthMonitor()
         self.alert_manager = AlertManager()
-        self.business_metrics: List[BusinessMetric] = []
+        self.business_metrics: Deque[BusinessMetric] = deque(maxlen=5000)
 
         # Register default health checks
         self._register_default_health_checks()
@@ -634,12 +654,6 @@ class MonitoringService:
         )
 
         self.business_metrics.append(metric)
-
-        # Keep only recent metrics
-        cutoff = datetime.utcnow() - timedelta(hours=24)
-        self.business_metrics = [
-            m for m in self.business_metrics if m.timestamp > cutoff
-        ]
 
     async def get_monitoring_dashboard(self) -> Dict[str, Any]:
         """Get comprehensive monitoring dashboard data."""

--- a/backend/production/rgl_core_service.py
+++ b/backend/production/rgl_core_service.py
@@ -14,6 +14,7 @@ Enterprise-grade Retrosplenial Gateway Layer service with:
 import asyncio
 import json
 import logging
+import os
 import time
 import uuid
 from dataclasses import asdict, dataclass
@@ -181,7 +182,13 @@ class RGLCoreService:
 
     def _setup_middleware(self):
         """Configure middleware"""
-        _cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
+        _cors_origins = [
+            o.strip()
+            for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(
+                ","
+            )
+            if o.strip()
+        ]
         self.app.add_middleware(
             CORSMiddleware,
             allow_origins=_cors_origins,

--- a/backend/production/rgl_core_service.py
+++ b/backend/production/rgl_core_service.py
@@ -181,12 +181,13 @@ class RGLCoreService:
 
     def _setup_middleware(self):
         """Configure middleware"""
+        _cors_origins = [o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
         self.app.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],  # Configure appropriately for production
+            allow_origins=_cors_origins,
             allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+            allow_headers=["Authorization", "Content-Type"],
         )
 
     def _setup_routes(self):

--- a/backend/resilience.py
+++ b/backend/resilience.py
@@ -248,6 +248,7 @@ class RetryPolicy:
         exponential_base: float = 2.0,
         jitter: bool = True,
         retryable_exceptions: tuple = (Exception,),
+        non_retryable_exceptions: tuple = (),
     ):
         """
         Initialize retry policy.
@@ -259,6 +260,8 @@ class RetryPolicy:
             exponential_base: Base for exponential backoff
             jitter: Add random jitter to delays
             retryable_exceptions: Exception types that trigger retries
+            non_retryable_exceptions: Subset of retryable exceptions to fail fast on
+                (e.g. AuthenticationError — permanent, no point retrying)
         """
         self.max_attempts = max_attempts
         self.base_delay = base_delay
@@ -266,6 +269,7 @@ class RetryPolicy:
         self.exponential_base = exponential_base
         self.jitter = jitter
         self.retryable_exceptions = retryable_exceptions
+        self.non_retryable_exceptions = non_retryable_exceptions
 
     def calculate_delay(self, attempt: int) -> float:
         """Calculate delay for given attempt number."""
@@ -306,6 +310,12 @@ async def with_retry(func: Callable, retry_policy: RetryPolicy, *args, **kwargs)
                 return func(*args, **kwargs)
 
         except retry_policy.retryable_exceptions as e:
+            # Fast-fail on permanent errors even if they are in retryable_exceptions
+            if retry_policy.non_retryable_exceptions and isinstance(
+                e, retry_policy.non_retryable_exceptions
+            ):
+                raise
+
             last_exception = e
 
             if attempt == retry_policy.max_attempts - 1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,12 @@ services:
     volumes:
       - neo4j_data:/data
       - ./neo4j/import:/var/lib/neo4j/import
-
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7474/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
     networks:
       - pythia-network
 
@@ -38,6 +43,11 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - pythia-network
 
@@ -48,6 +58,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
     ports:
       - "9090:9090"
     networks:
@@ -93,8 +104,10 @@ services:
       timeout: 10s
       retries: 3
     depends_on:
-      - neo4j
-      - redis
+      neo4j:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
 networks:
   pythia-network:
@@ -104,3 +117,4 @@ volumes:
   neo4j_data:
   redis_data:
   grafana_data:
+  prometheus_data:

--- a/frontend/consciousness_map/js/data-service.js
+++ b/frontend/consciousness_map/js/data-service.js
@@ -353,11 +353,11 @@ class DataService {
         }
       }));
       
-      this.links = data.transitions.map(transition => {
+      this.links = data.transitions.reduce((acc, transition) => {
         const source = this.nodes.find(node => node.id === transition.from_id);
         const target = this.nodes.find(node => node.id === transition.to_id);
-        
-        return {
+        if (!source || !target) return acc;
+        acc.push({
           id: `${transition.from_id}-${transition.to_id}`,
           source,
           target,
@@ -365,8 +365,9 @@ class DataService {
           triggerLabel: CONFIG.triggers[transition.trigger] || transition.trigger,
           count: transition.count || 1,
           lastTransitionData: transition.trigger_data || {}
-        };
-      });
+        });
+        return acc;
+      }, []);
       
       // Уведомляем подписчиков
       this.notifySubscribers();

--- a/frontend/consciousness_map/js/graph-renderer.js
+++ b/frontend/consciousness_map/js/graph-renderer.js
@@ -308,10 +308,12 @@ class GraphRenderer {
       
     // Отображаем инсайт в панели
     const insightPanel = document.getElementById('current-insight');
-    insightPanel.innerHTML = `
-      <h4>${state.label}</h4>
-      <p>${state.description}</p>
-    `;
+    insightPanel.textContent = '';
+    const _h4 = document.createElement('h4');
+    _h4.textContent = state.label;
+    const _p = document.createElement('p');
+    _p.textContent = state.description;
+    insightPanel.append(_h4, _p);
   }
   
   /**

--- a/frontend/consciousness_map/js/main.js
+++ b/frontend/consciousness_map/js/main.js
@@ -56,7 +56,7 @@ function connectToWebSocket() {
       header.appendChild(statusIndicator);
       
       // Обновляем индикатор при изменении состояния подключения
-      setInterval(() => {
+      app.statusPollInterval = setInterval(() => {
         const indicator = document.querySelector('.status-indicator');
         const statusText = document.querySelector('.status-text');
         if (indicator && statusText) {
@@ -258,6 +258,12 @@ function updateEmotimeBadge(mode, online) {
   `;
   badge.style.borderColor = meta.color;
 }
+
+// Очищаем таймеры при выгрузке страницы
+window.addEventListener('beforeunload', () => {
+  if (app.statusPollInterval) clearInterval(app.statusPollInterval);
+  if (app.emotimePollInterval) clearInterval(app.emotimePollInterval);
+});
 
 // Добавляем CSS для индикатора подключения
 const connectionStyle = document.createElement('style');

--- a/frontend/consciousness_map/js/state-controller.js
+++ b/frontend/consciousness_map/js/state-controller.js
@@ -186,11 +186,15 @@ class StateController {
       const insightPanel = document.getElementById('current-insight');
       const stateInfo = CONFIG.states[currentStep.state];
       
-      insightPanel.innerHTML = `
-        <h4>Утренний путь: ${stateInfo.label}</h4>
-        <p>${stateInfo.description}</p>
-        <p class="ritual-step">Шаг ${index + 1} из ${morningPath.length}</p>
-      `;
+      insightPanel.textContent = '';
+      const _h4 = document.createElement('h4');
+      _h4.textContent = `Утренний путь: ${stateInfo.label}`;
+      const _pDesc = document.createElement('p');
+      _pDesc.textContent = stateInfo.description;
+      const _pStep = document.createElement('p');
+      _pStep.className = 'ritual-step';
+      _pStep.textContent = `Шаг ${index + 1} из ${morningPath.length}`;
+      insightPanel.append(_h4, _pDesc, _pStep);
       
       // Переходим к следующему шагу через указанное время
       setTimeout(() => {

--- a/go_ws_relay/graphql/subscriptions.go
+++ b/go_ws_relay/graphql/subscriptions.go
@@ -131,13 +131,15 @@ func (sm *SubscriptionManager) HandleSubscription(w http.ResponseWriter, r *http
 	}
 	
 	conn.SetReadLimit(maxMessageSize)
-	
-	// Запускаем горутину для чтения сообщений
+
+	// done is closed when the read goroutine exits; it signals the ping goroutine to stop.
+	done := make(chan struct{})
+
+	// Read goroutine — owns the connection lifetime.
 	go func() {
-		defer func() {
-			conn.Close()
-		}()
-		
+		defer close(done)
+		defer conn.Close()
+
 		for {
 			messageType, message, err := conn.ReadMessage()
 			if err != nil {
@@ -146,42 +148,41 @@ func (sm *SubscriptionManager) HandleSubscription(w http.ResponseWriter, r *http
 				}
 				break
 			}
-			
+
 			if messageType == websocket.TextMessage {
 				var request map[string]interface{}
 				if err := json.Unmarshal(message, &request); err != nil {
 					log.Printf("Ошибка разбора JSON: %v", err)
 					continue
 				}
-				
-				// Обрабатываем запрос подписки
+
 				if requestType, ok := request["type"].(string); ok {
 					switch requestType {
 					case "subscribe":
-						topic, _ := request["topic"].(string)
+						topic, ok := request["topic"].(string)
+						if !ok || topic == "" {
+							log.Printf("Invalid or missing topic in subscribe request")
+							continue
+						}
 						filter, _ := request["filter"].(map[string]interface{})
 						id := sm.Subscribe(topic, conn, filter)
-						
-						// Отправляем подтверждение подписки
+
 						response := map[string]interface{}{
-							"type":        "subscribed",
-							"id":          id,
-							"topic":       topic,
+							"type":  "subscribed",
+							"id":    id,
+							"topic": topic,
 						}
-						
 						jsonResponse, _ := json.Marshal(response)
 						conn.WriteMessage(websocket.TextMessage, jsonResponse)
-						
+
 					case "unsubscribe":
 						id, _ := request["id"].(string)
 						sm.Unsubscribe(id)
-						
-						// Отправляем подтверждение отписки
+
 						response := map[string]interface{}{
 							"type": "unsubscribed",
 							"id":   id,
 						}
-						
 						jsonResponse, _ := json.Marshal(response)
 						conn.WriteMessage(websocket.TextMessage, jsonResponse)
 					}
@@ -189,17 +190,16 @@ func (sm *SubscriptionManager) HandleSubscription(w http.ResponseWriter, r *http
 			}
 		}
 	}()
-	
-	// Запускаем горутину для отправки ping сообщений
+
+	// Ping goroutine — exits when done is closed; does NOT close the connection.
 	go func() {
 		ticker := time.NewTicker(pingPeriod)
-		defer func() {
-			ticker.Stop()
-			conn.Close()
-		}()
-		
+		defer ticker.Stop()
+
 		for {
 			select {
+			case <-done:
+				return
 			case <-ticker.C:
 				conn.SetWriteDeadline(time.Now().Add(writeWait))
 				if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {

--- a/go_ws_relay/main.go
+++ b/go_ws_relay/main.go
@@ -51,21 +51,32 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 }
 
 func broadcastToClients(message string) {
-    // broadcast to all clients
-
+	// Snapshot clients under lock so writes don't block new connections.
 	clientsMutex.Lock()
-	defer clientsMutex.Unlock()
-	
-	activeClients := 0
+	snapshot := make([]*websocket.Conn, 0, len(clients))
 	for client := range clients {
-		err := client.WriteMessage(websocket.TextMessage, []byte(message))
-		if err != nil {
-			log.Printf("Error broadcasting message: %v", err)
+		snapshot = append(snapshot, client)
+	}
+	clientsMutex.Unlock()
+
+	var failed []*websocket.Conn
+	activeClients := 0
+	for _, client := range snapshot {
+		if err := client.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
+			log.Printf("Error broadcasting to client: %v", err)
 			client.Close()
-			delete(clients, client)
+			failed = append(failed, client)
 		} else {
 			activeClients++
 		}
+	}
+
+	if len(failed) > 0 {
+		clientsMutex.Lock()
+		for _, client := range failed {
+			delete(clients, client)
+		}
+		clientsMutex.Unlock()
 	}
 	log.Printf("Broadcasted message to %d clients: %s", activeClients, message)
 }

--- a/go_ws_relay/neo4j_api.go
+++ b/go_ws_relay/neo4j_api.go
@@ -5,16 +5,31 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
-// Neo4j credentials - эти же используются в Python backend
-const (
-	neo4jURI      = "neo4j://localhost:7687"
-	neo4jUsername = "neo4j"
-	neo4jPassword = "NewStrongPass123!"
+var (
+	neo4jURI      = getEnvOrDefault("NEO4J_URI", "neo4j://localhost:7687")
+	neo4jUsername = getEnvOrDefault("NEO4J_USERNAME", "neo4j")
+	neo4jPassword = mustGetEnv("NEO4J_PASSWORD")
 )
+
+func getEnvOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func mustGetEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		log.Fatalf("required environment variable %s is not set", key)
+	}
+	return v
+}
 
 // GraphData структура для представления графа состояний сознания
 type GraphData struct {
@@ -125,32 +140,44 @@ func getConsciousnessGraphFromNeo4j() (*GraphData, error) {
 	nodeIDs := make(map[string]bool)
 	for nodeRecords.Next() {
 		record := nodeRecords.Record()
-		
-		id, _ := record.Get("id")
-		state, _ := record.Get("state")
-		label, _ := record.Get("label")
-		description, _ := record.Get("description")
-		presenceLevel, _ := record.Get("presenceLevel")
-		harmonyIndex, _ := record.Get("harmonyIndex")
-		authenticityScore, _ := record.Get("authenticityScore")
-		emotionalCharge, _ := record.Get("emotionalCharge")
-		
-		// Создаем узел
-		node := Node{
-			ID:                id.(string),
-			State:             state.(string),
-			Label:             label.(string),
-			Description:       description.(string),
-			PresenceLevel:     presenceLevel.(float64),
-			HarmonyIndex:      harmonyIndex.(float64),
-			AuthenticityScore: authenticityScore.(float64),
-			EmotionalCharge:   emotionalCharge.(float64),
-			ColorClass:        "node-" + state.(string),
+
+		idVal, _ := record.Get("id")
+		stateVal, _ := record.Get("state")
+		labelVal, _ := record.Get("label")
+		descVal, _ := record.Get("description")
+		presenceVal, _ := record.Get("presenceLevel")
+		harmonyVal, _ := record.Get("harmonyIndex")
+		authVal, _ := record.Get("authenticityScore")
+		chargeVal, _ := record.Get("emotionalCharge")
+
+		id, ok1 := idVal.(string)
+		stateStr, ok2 := stateVal.(string)
+		labelStr, ok3 := labelVal.(string)
+		descStr, ok4 := descVal.(string)
+		presenceLevel, ok5 := presenceVal.(float64)
+		harmonyIndex, ok6 := harmonyVal.(float64)
+		authenticityScore, ok7 := authVal.(float64)
+		emotionalCharge, ok8 := chargeVal.(float64)
+
+		if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 || !ok8 {
+			log.Printf("Skipping node record with unexpected field types: id=%v state=%v", idVal, stateVal)
+			continue
 		}
-		
-		// Добавляем узел в результат
+
+		node := Node{
+			ID:                id,
+			State:             stateStr,
+			Label:             labelStr,
+			Description:       descStr,
+			PresenceLevel:     presenceLevel,
+			HarmonyIndex:      harmonyIndex,
+			AuthenticityScore: authenticityScore,
+			EmotionalCharge:   emotionalCharge,
+			ColorClass:        "node-" + stateStr,
+		}
+
 		result.Nodes = append(result.Nodes, node)
-		nodeIDs[id.(string)] = true
+		nodeIDs[id] = true
 	}
 	
 	// Получение связей (переходов)
@@ -169,27 +196,34 @@ func getConsciousnessGraphFromNeo4j() (*GraphData, error) {
 	// Обработка результатов запроса связей
 	for linkRecords.Next() {
 		record := linkRecords.Record()
-		
-		sourceId, _ := record.Get("sourceId")
-		targetId, _ := record.Get("targetId")
-		trigger, _ := record.Get("trigger")
-		count, _ := record.Get("count")
-		
-		// Проверяем, что узлы существуют
-		if !nodeIDs[sourceId.(string)] || !nodeIDs[targetId.(string)] {
+
+		srcVal, _ := record.Get("sourceId")
+		tgtVal, _ := record.Get("targetId")
+		triggerVal, _ := record.Get("trigger")
+		countVal, _ := record.Get("count")
+
+		sourceID, ok1 := srcVal.(string)
+		targetID, ok2 := tgtVal.(string)
+		trigger, ok3 := triggerVal.(string)
+		countInt, ok4 := countVal.(int64)
+
+		if !ok1 || !ok2 || !ok3 || !ok4 {
+			log.Printf("Skipping link record with unexpected field types: src=%v tgt=%v", srcVal, tgtVal)
 			continue
 		}
-		
-		// Создаем связь
-		link := Link{
-			ID:       sourceId.(string) + "-" + targetId.(string),
-			Source:   sourceId.(string),
-			Target:   targetId.(string),
-			Trigger:  trigger.(string),
-			Count:    int(count.(int64)),
+
+		if !nodeIDs[sourceID] || !nodeIDs[targetID] {
+			continue
 		}
-		
-		// Добавляем связь в результат
+
+		link := Link{
+			ID:      sourceID + "-" + targetID,
+			Source:  sourceID,
+			Target:  targetID,
+			Trigger: trigger,
+			Count:   int(countInt),
+		}
+
 		result.Links = append(result.Links, link)
 	}
 	

--- a/test_runner.py
+++ b/test_runner.py
@@ -260,7 +260,7 @@ def generate_test_report(results):
     print(f"Total Tests: {total_tests}")
     print(f"Passed: {passed_tests}")
     print(f"Failed: {failed_tests}")
-    print(f"Success Rate: {(passed_tests/total_tests)*100:.1f}%")
+    print(f"Success Rate: {(passed_tests/total_tests)*100:.1f}%" if total_tests > 0 else "Success Rate: N/A")
 
     print("\nDetailed Results:")
     for test_name, result in results.items():
@@ -275,7 +275,7 @@ def generate_test_report(results):
                 "total_tests": total_tests,
                 "passed_tests": passed_tests,
                 "failed_tests": failed_tests,
-                "success_rate": (passed_tests / total_tests) * 100,
+                "success_rate": (passed_tests / total_tests * 100) if total_tests > 0 else 0,
                 "results": results,
                 "timestamp": str(Path(__file__).stat().st_mtime),
             },

--- a/test_runner.py
+++ b/test_runner.py
@@ -260,7 +260,11 @@ def generate_test_report(results):
     print(f"Total Tests: {total_tests}")
     print(f"Passed: {passed_tests}")
     print(f"Failed: {failed_tests}")
-    print(f"Success Rate: {(passed_tests/total_tests)*100:.1f}%" if total_tests > 0 else "Success Rate: N/A")
+    print(
+        f"Success Rate: {(passed_tests/total_tests)*100:.1f}%"
+        if total_tests > 0
+        else "Success Rate: N/A"
+    )
 
     print("\nDetailed Results:")
     for test_name, result in results.items():
@@ -275,7 +279,9 @@ def generate_test_report(results):
                 "total_tests": total_tests,
                 "passed_tests": passed_tests,
                 "failed_tests": failed_tests,
-                "success_rate": (passed_tests / total_tests * 100) if total_tests > 0 else 0,
+                "success_rate": (
+                    (passed_tests / total_tests * 100) if total_tests > 0 else 0
+                ),
                 "results": results,
                 "timestamp": str(Path(__file__).stat().st_mtime),
             },

--- a/webapp/src/app/progress/page.tsx
+++ b/webapp/src/app/progress/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { api, ProgressResult, RISK_COLORS, TREND_META, fmtPct, fmtDate } from '@/lib/api';
 
 const CARD: React.CSSProperties = {
@@ -76,12 +76,12 @@ export default function ProgressPage() {
   const [days, setDays]         = useState(30);
   const [loading, setLoading]   = useState(false);
 
-  const load = async (d: number) => {
+  const load = useCallback(async (d: number) => {
     setLoading(true);
     try { setData(await api.progress(undefined, d)); } catch { setData(null); } finally { setLoading(false); }
-  };
+  }, []);
 
-  useEffect(() => { load(days); }, []);
+  useEffect(() => { load(days); }, [days, load]);
 
   const summary = data?.summary;
   const trendMeta = summary ? TREND_META[summary.trend] : null;


### PR DESCRIPTION
## Summary

- **LRU query cache** — `OrderedDict` с лимитом 1000 записей вместо unbounded dict; вытесняет oldest entry при переполнении, `move_to_end` при cache hit
- **Bounded business metrics** — `deque(maxlen=5000)` вместо O(n) list-filter; запись метрик теперь O(1)
- **Stale span cleanup** — active tracing spans, висящие >5 мин, принудительно закрываются; cap 100 log entries на span
- **Non-retryable exceptions** — `RetryPolicy` получил `non_retryable_exceptions`: постоянные ошибки (auth, validation) не тратят retry budget
- **WebSocket auth timeout** — `asyncio.wait_for(..., timeout=30s)` при ожидании auth-сообщения; устраняет зависшие неавторизованные соединения
- **Non-blocking Go broadcast** — снимок `clients` под lock, release lock перед записью; устраняет head-of-line blocking в WebSocket relay
- **Docker health checks** — `healthcheck` для Neo4j и Redis, `depends_on: condition: service_healthy`; backend не стартует до готовности БД
- **Prometheus volume** — `prometheus_data` volume для персистентности метрик между рестартами
- **Debug prints** — заменены на `logger.debug/error`; slow-query log лимит 100→1000

## Test plan
- [ ] CI quality-checks (black, isort, flake8, mypy)
- [ ] CI test suite
- [ ] CI smoke

https://claude.ai/code/session_01RdDkzkmeqRmDawWJM3zjTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdDkzkmeqRmDawWJM3zjTK)_