### PR TITLE
ci: improve WebSocket readiness diagnostics

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    env:
+      ENV: test
+      USE_REDIS: "false"
+      USE_REDIS_CLIENT: "false"
+      ML_ENABLED: "false"
 
     steps:
     - uses: actions/checkout@v4
@@ -27,10 +32,16 @@ jobs:
 
     - name: Start backend (uvicorn on 8080) and wait readiness
       run: |
+        set -euo pipefail
         export PYTHONPATH="${PWD}:${PYTHONPATH}"
-        uvicorn backend.main:app --host 127.0.0.1 --port 8080 &
+        uvicorn backend.main:app --host 127.0.0.1 --port 8080 > uvicorn.log 2>&1 &
         echo $! > uvicorn.pid
-        bash scripts/check-health.sh --url http://127.0.0.1:8080 --retries 60 --delay 1 --fail-on-not-ready
+        if ! bash scripts/check-health.sh --url http://127.0.0.1:8080 --retries 60 --delay 1 --fail-on-not-ready; then
+          echo
+          echo "— uvicorn.log —"
+          cat uvicorn.log || true
+          exit 1
+        fi
 
     - name: Run WebSocket integration tests
       env:
@@ -45,3 +56,8 @@ jobs:
       if: always()
       run: |
         if [ -f uvicorn.pid ]; then kill $(cat uvicorn.pid) || true; fi
+        if [ -f uvicorn.log ]; then
+          echo
+          echo "— final uvicorn.log —"
+          cat uvicorn.log || true
+        fi

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -2,6 +2,8 @@ name: Python Integration (WS)
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'  # daily at 03:00 UTC

--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -1,6 +1,7 @@
 name: Python Integration (WS)
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'  # daily at 03:00 UTC


### PR DESCRIPTION
## Summary

- Runs the Python integration workflow in explicit test mode.
- Disables Redis-backed WebSocket managers for this smoke-level CI path.
- Captures uvicorn output to `uvicorn.log` and prints it if readiness fails.
- Prints final backend logs during cleanup.

## Why

The scheduled `Python Integration (WS)` workflow failed before WebSocket tests started, at the backend readiness step. The previous workflow launched uvicorn in the background without preserving backend logs, so the failure could not be diagnosed from the job output.

This keeps the readiness gate strict while making failures actionable.

## Related

Fixes #95.