### PR TITLE
ci: handle empty PYTHONPATH in WebSocket integration workflow

### DIFF
--- a/.github/workflows/python-integration.yml
+++ b/.github/workflows/python-integration.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Start backend (uvicorn on 8080) and wait readiness
       run: |
         set -euo pipefail
-        export PYTHONPATH="${PWD}:${PYTHONPATH}"
+        export PYTHONPATH="${PWD}:${PYTHONPATH:-}"
         uvicorn backend.main:app --host 127.0.0.1 --port 8080 > uvicorn.log 2>&1 &
         echo $! > uvicorn.pid
         if ! bash scripts/check-health.sh --url http://127.0.0.1:8080 --retries 60 --delay 1 --fail-on-not-ready; then
@@ -51,7 +51,7 @@ jobs:
         WS_API_URL: http://localhost:8080
         WS_URL: ws://localhost:8080/ws
       run: |
-        export PYTHONPATH="${PWD}:${PYTHONPATH}"
+        export PYTHONPATH="${PWD}:${PYTHONPATH:-}"
         # These tests are smoke-level and skip themselves if server is down
         python -m pytest -v -m integration --maxfail=1 --durations=10
 


### PR DESCRIPTION
## Summary

- Fixes `set -u` compatibility when `PYTHONPATH` is not predefined in GitHub Actions.
- Uses `${PYTHONPATH:-}` in both backend startup and WebSocket test steps.

## Why

After #96, the workflow became stricter with `set -euo pipefail`. On a clean GitHub runner, `PYTHONPATH` may be unset, which can fail the readiness step before uvicorn even starts.

This keeps the stricter shell mode while making the workflow safe on fresh CI runners.

## Related

Follow-up for #95 and #96.