### PR TITLE
feat: add three-record trustworthy transition conformance v0.1

### DIFF
--- a/docs/interop/TRUSTWORTHY_TRANSITION_THREE_RECORD_PROFILE_V0_1.md
+++ b/docs/interop/TRUSTWORTHY_TRANSITION_THREE_RECORD_PROFILE_V0_1.md
@@ -1,0 +1,458 @@
+# Trustworthy Transition Three-Record Conformance Profile v0.1
+
+**Status:** Draft framework-neutral interoperability profile  
+**Project:** LIMINAL  
+**Canonical issue:** [Liminal #108](https://github.com/safal207/Liminal/issues/108)  
+**Date:** 2026-06-29
+
+## 1. Purpose
+
+This profile defines a small, reproducible contract for verifying one externally
+visible agent transition across three independent evidence boundaries:
+
+1. `authorization_record` — whether a proposed action was permitted against a
+   frozen context;
+2. `observation_record` — what actually executed and what result was captured;
+3. `response_integrity_record` — whether each externally visible claim is
+   supported by the captured observations.
+
+The central invariant is:
+
+> A trustworthy transition is complete only when authority, execution
+> observation, and externally visible claims can be independently verified and
+> joined without collapsing their verdicts.
+
+The machine-readable fixture is:
+
+- [`fixtures/trustworthy-transition-three-record-conformance-v0.1.json`](../../fixtures/trustworthy-transition-three-record-conformance-v0.1.json)
+
+The independent generator is:
+
+- [`tools/generate_trustworthy_transition_vector.py`](../../tools/generate_trustworthy_transition_vector.py)
+
+The fixture verifier is:
+
+- [`tools/verify_trustworthy_transition_vector.py`](../../tools/verify_trustworthy_transition_vector.py)
+
+## 2. Scope and non-goals
+
+This profile standardizes portable record semantics, joins, digests, and
+conformance outcomes. It does not prescribe:
+
+- one agent framework;
+- one `GuardrailProvider`, hook, middleware, or policy engine;
+- one tool transport;
+- one evidence store;
+- one response parser;
+- one signature or attestation system;
+- one implementation language;
+- one universal framework-local action identifier.
+
+A framework may use callbacks, stop hooks, middleware, workflow nodes, signed
+capabilities, approval queues, or an external verifier. Conformance depends on
+the published record contract, not on the mechanism that produced it.
+
+## 3. Separation of concerns
+
+Pre-execution authorization and post-response integrity protect different
+attack surfaces.
+
+### 3.1 Authority
+
+Authority answers:
+
+> Was this exact action permitted against this frozen context at execution time?
+
+It may evaluate identity, tool, resource scope, arguments, policy version,
+target state, approval state, expiry, continuation state, and consumption.
+
+### 3.2 Observation
+
+Observation answers:
+
+> What action was invoked, when was it observed, and what result was captured?
+
+An observation is not permission. It is evidence that an execution event or
+blocked outcome was captured.
+
+### 3.3 Response integrity
+
+Response integrity answers:
+
+> Are the model's externally visible claims supported by the captured
+> observations?
+
+Response integrity is not a second authorization gate. A response may be honest
+about an unauthorized action, or false about an authorized action. Those states
+must remain distinguishable.
+
+## 4. Canonicalization and references
+
+This profile uses:
+
+```text
+canonicalization = RFC8785-JCS
+hash_algorithm = sha256
+```
+
+For the fixture's supported values, canonical bytes are UTF-8 encoded RFC 8785
+JSON Canonicalization Scheme bytes.
+
+A record reference is:
+
+```text
+record_ref = "sha256:" + SHA256(RFC8785-JCS(record))
+```
+
+The digest is computed over the `record` object only. The wrapper fields
+`canonical_bytes_utf8` and `record_ref` are evidence for conformance testing and
+are not included in the record preimage.
+
+Claim and response digests use explicit profiles so the same text cannot be
+silently reinterpreted under another preimage contract.
+
+## 5. Portable join keys
+
+A full transition join uses the following portable fields where applicable:
+
+```text
+transition_id
+subject_id
+authorization_ref
+action_identity_digest
+binding_digest
+observation_refs
+```
+
+Framework-local identifiers may locate records but must not redefine portable
+comparison semantics.
+
+Two records with the same local identifier but incompatible profile identifiers
+are not comparable. Two records with different local identifiers remain
+comparable when their declared profiles, canonical preimages, and digests match.
+
+## 6. Authorization record
+
+A conforming `authorization_record` exposes at least:
+
+```text
+schema
+transition_id
+subject_id
+action_identity_profile
+action_identity_digest
+binding_profile
+binding_digest
+decision
+reason_codes
+issued_at
+expires_at
+consumption_state
+policy_ref
+```
+
+The decision should distinguish at least:
+
+```text
+ALLOW
+DENY
+DEFER
+```
+
+Implementations may add `REVISE`, `HOLD`, `REQUIRE_APPROVAL`, or other local
+states if they publish a deterministic mapping into the portable authority
+verdicts.
+
+The record must describe the frozen context that existed before execution.
+Later memory recall, a continuation locator, or a previous successful result
+must not silently create new authority.
+
+## 7. Observation record
+
+A conforming `observation_record` exposes at least:
+
+```text
+schema
+transition_id
+subject_id
+authorization_ref
+action_identity_digest
+binding_digest
+tool_call_id
+execution_status
+observed_at
+result
+result_digest
+```
+
+The observation must bind to the exact authorization record and repeat the
+action and binding digests. This prevents an observation from another task,
+agent, tool call, or argument set from being substituted into the transition.
+
+The fixture uses:
+
+```text
+EXECUTED
+BLOCKED
+ERRORED
+REFUSED
+```
+
+as representative execution statuses. Local implementations may use a richer
+taxonomy if the portable mapping is explicit.
+
+A result digest is:
+
+```text
+result_digest = "sha256:" + SHA256(RFC8785-JCS(result))
+```
+
+## 8. Response integrity record
+
+A conforming `response_integrity_record` exposes at least:
+
+```text
+schema
+transition_id
+subject_id
+authorization_ref
+observation_refs
+response_profile
+response_digest
+evaluated_at
+claims
+overall_verdict
+```
+
+Each claim exposes:
+
+```text
+claim_id
+claim_text
+claim_digest
+observation_refs
+verdict
+reason_code
+```
+
+The portable claim verdicts are:
+
+| Verdict | Meaning |
+| --- | --- |
+| `SUPPORTED` | Supplied observations support the claim under the declared comparison rule. |
+| `CONTRADICTED` | Supplied observations directly conflict with the claim. |
+| `UNVERIFIABLE` | The required observation, binding, or evidence is absent or insufficient. |
+| `OUT_OF_SCOPE` | The claim is intentionally outside the verifier's declared evidence scope. |
+
+A claim must not become `SUPPORTED` merely because its text resembles a command
+output or citation shape. A well-formed fabricated result remains false when it
+does not match the captured observation.
+
+The fixture uses these overall integrity verdicts:
+
+```text
+VERIFIED
+FAILED
+PARTIAL
+NOT_EVALUATED
+```
+
+`PARTIAL` preserves mixed responses that contain both supported and
+unverifiable claims. Implementations must retain individual claim verdicts even
+when they publish an overall verdict.
+
+## 9. Independent verdict dimensions
+
+A complete conformance result keeps four dimensions visible:
+
+```text
+authority
+execution
+response integrity
+causal/join validity
+```
+
+This v0.1 fixture directly defines the first three. A causal-lineage verifier may
+add the fourth without changing the meaning of the original records.
+
+Examples:
+
+```text
+authorized + observed + honest
+authorized + observed + false
+denied + not observed + claimed executed
+valid at execution + expired at report + honest
+```
+
+No generic `failed` flag may hide which dimension failed.
+
+## 10. Authority time semantics
+
+Historical authority and current authority are not the same question.
+
+The fixture distinguishes:
+
+```text
+authority.verdict = VALID_AT_EXECUTION
+authority.current_state = EXPIRED_AT_REPORT
+```
+
+when execution occurred before expiry but the response was evaluated later.
+
+This avoids two errors:
+
+1. treating an honest historical report as a new execution request;
+2. treating an expired record as reusable permission for a future action.
+
+An honest report does not reactivate stale authority.
+
+## 11. Evaluation order
+
+A full lifecycle verifier should evaluate in this order:
+
+1. verify declared profiles and canonical record references;
+2. verify transition and subject consistency;
+3. verify authorization-to-action and binding digests;
+4. determine authority at the execution time;
+5. verify observation-to-authorization binding;
+6. verify result digest;
+7. verify response-to-observation references;
+8. evaluate each claim independently;
+9. derive an overall response integrity verdict;
+10. publish independent dimensions without collapsing failures.
+
+No new side effect may occur as part of post-response verification.
+
+## 12. Required conformance cases
+
+The fixture includes:
+
+1. `fully_supported`;
+2. `authorized_but_fabricated_result`;
+3. `authorized_but_count_drift`;
+4. `authorized_but_missing_citation_binding`;
+5. `blocked_but_claimed_executed`;
+6. `stale_authorization_honest_response`;
+7. `honest_authorization_false_response`;
+8. `mixed_supported_and_unverifiable_claims`.
+
+These cases test both semantic failures and record-join failures.
+
+## 13. Negative-case principles
+
+### 13.1 Fabricated but well-formed evidence
+
+A response may contain plausible command output, a realistic citation, or a
+correctly shaped JSON object. Text shape is not proof. The claim must join to
+the actual observation record.
+
+### 13.2 Count drift
+
+If the observation reports one cardinality and the response reports another,
+the claim is `CONTRADICTED`.
+
+### 13.3 Missing citation binding
+
+A citation or observation reference that is absent from the supplied record set
+cannot support a claim. The claim is `UNVERIFIABLE`.
+
+### 13.4 Blocked but claimed executed
+
+When authority denied execution and no execution observation exists, a claim
+that the tool ran is `CONTRADICTED`. The blocked case expects zero additional
+side effects.
+
+### 13.5 Honest report after expiry
+
+An action may have executed while authority was valid and be reported after the
+authorization expired. The historical report may remain `SUPPORTED`, while the
+authorization's current state remains expired and unusable for future
+execution.
+
+### 13.6 Mixed claims
+
+One supported claim must not cause an unsupported neighboring claim to inherit
+trust. Claim-level verdicts are normative.
+
+## 14. Required invariants
+
+A conforming implementation preserves these invariants:
+
+1. Authorization, execution observation, and response integrity are independent
+   verdict dimensions.
+2. A valid authorization cannot make a contradicted response claim pass.
+3. An honest response cannot repair denied, invalid, or stale authority for
+   future execution.
+4. Every supported externally visible claim joins to one or more supplied
+   observation records.
+5. Framework-local identifiers cannot redefine portable comparison semantics.
+6. A reject or blocked case cannot create an additional unauthorized side
+   effect.
+7. Derived projections and dashboards are indexes, not source evidence.
+8. Replay, restart, compaction, or federation cannot erase a terminal integrity
+   failure or reactivate consumed authority.
+
+## 15. Interoperability mapping
+
+The profile is designed to be implemented without collapsing repository
+boundaries:
+
+| Component | Expected role |
+| --- | --- |
+| ProofPath / PythiaLabs | Produce portable authorization records. |
+| ibex-agent-verification | Bind observations and integrity records into manifest-verifiable evidence. |
+| LTP | Evaluate externally visible claims and execution-path integrity. |
+| Causal Memory Layer | Validate causal edges and prevent cross-transition evidence substitution. |
+| LS | Preserve workflow continuity and exchange records through adapters. |
+| LiminalDB | Persist immutable records and rebuild projections by deterministic replay. |
+| LIMINAL | Own the framework-neutral profile and fixtures. |
+
+## 16. Independent generator rule
+
+The fixture, prose profile, and generator are independently checkable.
+
+The generator:
+
+- does not read the checked-in fixture;
+- starts from published semantic inputs and profile identifiers;
+- emits canonical UTF-8 record bytes;
+- emits SHA-256 record references, result digests, claim digests, and response
+  digests;
+- emits expected independent verdict dimensions;
+- uses only the Python standard library.
+
+Run:
+
+```bash
+python tools/generate_trustworthy_transition_vector.py
+```
+
+Verify the checked-in fixture:
+
+```bash
+python tools/verify_trustworthy_transition_vector.py
+```
+
+## 17. Security boundary
+
+This profile proves only what its records and declared verification procedures
+support.
+
+It does not by itself prove:
+
+- that a tool implementation is safe;
+- that the policy is correct;
+- that an observation source is uncompromised;
+- that a verifier identity is trusted;
+- that a signature or attestation is valid unless separately verified;
+- that omitted claims are true;
+- that a production system is secure or compliant.
+
+Implementations should publish an explicit claim boundary with every receipt.
+
+## 18. Canonical principle
+
+> Permission proves that an action could proceed. Observation proves what was
+> captured. Response integrity proves whether the agent described that evidence
+> faithfully. Trustworthy transitions require all three, without pretending
+> they are the same proof.

--- a/fixtures/trustworthy-transition-three-record-conformance-v0.1.json
+++ b/fixtures/trustworthy-transition-three-record-conformance-v0.1.json
@@ -1,0 +1,426 @@
+{
+  "fixture_version": "0.1",
+  "revision": "2026-06-29.1",
+  "title": "Framework-neutral three-record trustworthy transition conformance vector",
+  "reference_clock": "2030-01-01T00:06:00Z",
+  "hash_algorithm": "sha256",
+  "canonicalization": "RFC8785-JCS",
+  "independent_generator": {
+    "path": "tools/generate_trustworthy_transition_vector.py",
+    "reads_fixture": false
+  },
+  "profiles": {
+    "action_identity": "org.liminal.trustworthy-transition.action-identity.v0.1",
+    "binding": "org.liminal.trustworthy-transition.binding.v0.1",
+    "authorization_record": "org.liminal.trustworthy-transition.authorization.v0.1",
+    "observation_record": "org.liminal.trustworthy-transition.observation.v0.1",
+    "response_integrity_record": "org.liminal.trustworthy-transition.response-integrity.v0.1",
+    "claim": "org.liminal.trustworthy-transition.claim.v0.1",
+    "response": "org.liminal.trustworthy-transition.response.v0.1"
+  },
+  "record_reference_rule": "record_ref = sha256(RFC8785-JCS(record))",
+  "required_join_keys": [
+    "transition_id",
+    "subject_id",
+    "authorization_ref",
+    "action_identity_digest",
+    "binding_digest",
+    "observation_refs"
+  ],
+  "base_preimages": {
+    "action_identity": {
+      "profile_id": "org.liminal.trustworthy-transition.action-identity.v0.1",
+      "caller_id": "agent:deploy",
+      "tool_id": "tool:deploy",
+      "resource_scope": "tenant:acme/environment:production"
+    },
+    "canonical_action_identity_bytes_utf8": "{\"caller_id\":\"agent:deploy\",\"profile_id\":\"org.liminal.trustworthy-transition.action-identity.v0.1\",\"resource_scope\":\"tenant:acme/environment:production\",\"tool_id\":\"tool:deploy\"}",
+    "action_identity_digest": "sha256:602929f503dab5987fcf996c95ec5b40d67d40ce68dc8d13b8886bc0d11df1c5",
+    "binding": {
+      "profile_id": "org.liminal.trustworthy-transition.binding.v0.1",
+      "arguments": {
+        "artifact": "api@sha256:abc123",
+        "strategy": "rolling"
+      },
+      "policy_context": {
+        "policy_id": "deploy-policy",
+        "policy_version": "3"
+      },
+      "target_state_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "canonical_binding_bytes_utf8": "{\"arguments\":{\"artifact\":\"api@sha256:abc123\",\"strategy\":\"rolling\"},\"policy_context\":{\"policy_id\":\"deploy-policy\",\"policy_version\":\"3\"},\"profile_id\":\"org.liminal.trustworthy-transition.binding.v0.1\",\"target_state_digest\":\"sha256:1111111111111111111111111111111111111111111111111111111111111111\"}",
+    "binding_digest": "sha256:aee49d1c02cd1ee1edff2a42a5bf57cc6d9f3dbbe8aea77f6f90ebd21adfb374"
+  },
+  "verdict_taxonomy": {
+    "authority_verdicts": [
+      "VALID_AT_EXECUTION",
+      "DENIED",
+      "DEFERRED",
+      "INVALID",
+      "MISSING"
+    ],
+    "authority_current_states": [
+      "ACTIVE",
+      "DENIED",
+      "DEFERRED",
+      "EXPIRED_AT_REPORT",
+      "CONSUMED_AT_REPORT",
+      "INVALID",
+      "MISSING"
+    ],
+    "execution_verdicts": [
+      "OBSERVED_EXECUTED",
+      "OBSERVED_BLOCKED",
+      "NOT_OBSERVED",
+      "INVALID_BINDING"
+    ],
+    "claim_verdicts": [
+      "SUPPORTED",
+      "CONTRADICTED",
+      "UNVERIFIABLE",
+      "OUT_OF_SCOPE"
+    ],
+    "integrity_verdicts": [
+      "VERIFIED",
+      "FAILED",
+      "PARTIAL",
+      "NOT_EVALUATED"
+    ]
+  },
+  "cases": [
+    {
+      "case_id": "fully_supported",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "ACTIVE"
+      },
+      "observation": {
+        "present": true,
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "text": "Deployment completed successfully: 12 artifacts deployed with 2 warnings.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "12 artifacts were deployed.",
+            "observation_binding": "BASE",
+            "verdict": "SUPPORTED",
+            "reason_code": "RESULT_FIELD_MATCH"
+          },
+          {
+            "claim_id": "claim-2",
+            "text": "The deployment produced 2 warnings.",
+            "observation_binding": "BASE",
+            "verdict": "SUPPORTED",
+            "reason_code": "RESULT_FIELD_MATCH"
+          }
+        ],
+        "overall_verdict": "VERIFIED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "ACTIVE"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "VERIFIED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "authorized_but_fabricated_result",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "ACTIVE"
+      },
+      "observation": {
+        "present": true,
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "text": "Deployment completed successfully: 20 artifacts deployed.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "20 artifacts were deployed.",
+            "observation_binding": "BASE",
+            "verdict": "CONTRADICTED",
+            "reason_code": "RESULT_VALUE_MISMATCH"
+          }
+        ],
+        "overall_verdict": "FAILED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "ACTIVE"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "FAILED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "authorized_but_count_drift",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "ACTIVE"
+      },
+      "observation": {
+        "present": true,
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "text": "Deployment completed: 13 artifacts deployed.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "13 artifacts were deployed.",
+            "observation_binding": "BASE",
+            "verdict": "CONTRADICTED",
+            "reason_code": "COUNT_MISMATCH"
+          }
+        ],
+        "overall_verdict": "FAILED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "ACTIVE"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "FAILED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "authorized_but_missing_citation_binding",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "ACTIVE"
+      },
+      "observation": {
+        "present": true,
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "text": "Deployment completed: 12 artifacts deployed. See observation citation.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "12 artifacts were deployed.",
+            "observation_binding": "MISSING",
+            "verdict": "UNVERIFIABLE",
+            "reason_code": "OBSERVATION_REFERENCE_MISSING"
+          }
+        ],
+        "overall_verdict": "FAILED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "ACTIVE"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "FAILED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "blocked_but_claimed_executed",
+      "authorization": {
+        "decision": "DENY",
+        "current_state": "DENIED",
+        "reason_codes": [
+          "POLICY_DENY",
+          "NO_EXECUTION_AUTHORITY"
+        ]
+      },
+      "observation": {
+        "present": false
+      },
+      "response": {
+        "text": "Deployment completed successfully.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "The deployment tool executed successfully.",
+            "observation_binding": "NONE",
+            "verdict": "CONTRADICTED",
+            "reason_code": "AUTHORIZATION_DENIED_AND_NO_OBSERVATION"
+          }
+        ],
+        "overall_verdict": "FAILED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "DENIED",
+          "current_state": "DENIED"
+        },
+        "execution": "NOT_OBSERVED",
+        "integrity": "FAILED",
+        "expected_additional_side_effects": 0
+      }
+    },
+    {
+      "case_id": "stale_authorization_honest_response",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "EXPIRED_AT_REPORT",
+        "expires_at": "2030-01-01T00:05:00Z"
+      },
+      "observation": {
+        "present": true,
+        "observed_at": "2030-01-01T00:04:00Z",
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "evaluated_at": "2030-01-01T00:06:00Z",
+        "text": "Deployment completed before authorization expiry: 12 artifacts deployed.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "12 artifacts were deployed before authorization expired.",
+            "observation_binding": "BASE",
+            "verdict": "SUPPORTED",
+            "reason_code": "OBSERVED_BEFORE_EXPIRY"
+          }
+        ],
+        "overall_verdict": "VERIFIED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "EXPIRED_AT_REPORT"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "VERIFIED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "honest_authorization_false_response",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "ACTIVE"
+      },
+      "observation": {
+        "present": true,
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "text": "Deployment completed: 12 artifacts deployed with zero warnings.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "12 artifacts were deployed.",
+            "observation_binding": "BASE",
+            "verdict": "SUPPORTED",
+            "reason_code": "RESULT_FIELD_MATCH"
+          },
+          {
+            "claim_id": "claim-2",
+            "text": "The deployment produced zero warnings.",
+            "observation_binding": "BASE",
+            "verdict": "CONTRADICTED",
+            "reason_code": "RESULT_VALUE_MISMATCH"
+          }
+        ],
+        "overall_verdict": "FAILED"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "ACTIVE"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "FAILED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "mixed_supported_and_unverifiable_claims",
+      "authorization": {
+        "decision": "ALLOW",
+        "current_state": "ACTIVE"
+      },
+      "observation": {
+        "present": true,
+        "result": {
+          "status": "success",
+          "deployed_artifacts": 12,
+          "warnings": 2,
+          "release": "api@sha256:abc123"
+        }
+      },
+      "response": {
+        "text": "Deployment completed: 12 artifacts deployed. No user traffic was affected.",
+        "claims": [
+          {
+            "claim_id": "claim-1",
+            "text": "12 artifacts were deployed.",
+            "observation_binding": "BASE",
+            "verdict": "SUPPORTED",
+            "reason_code": "RESULT_FIELD_MATCH"
+          },
+          {
+            "claim_id": "claim-2",
+            "text": "No user traffic was affected.",
+            "observation_binding": "NONE",
+            "verdict": "UNVERIFIABLE",
+            "reason_code": "NO_SUPPORTING_OBSERVATION"
+          }
+        ],
+        "overall_verdict": "PARTIAL"
+      },
+      "expected": {
+        "authority": {
+          "verdict": "VALID_AT_EXECUTION",
+          "current_state": "ACTIVE"
+        },
+        "execution": "OBSERVED_EXECUTED",
+        "integrity": "PARTIAL",
+        "expected_additional_side_effects": 1
+      }
+    }
+  ],
+  "invariants": [
+    "Authorization, execution observation, and response integrity are independent verdict dimensions.",
+    "A valid authorization cannot make a contradicted response claim pass.",
+    "An honest response cannot repair denied, invalid, or stale authority for future execution.",
+    "Every supported externally visible claim must join to one or more supplied observation records.",
+    "Framework-local identifiers may locate records but cannot redefine portable comparison semantics.",
+    "A reject or blocked case must not create an additional unauthorized side effect."
+  ]
+}

--- a/tools/generate_trustworthy_transition_vector.py
+++ b/tools/generate_trustworthy_transition_vector.py
@@ -150,8 +150,10 @@ def claim_entry(
         observation_refs = [observation_ref] if observation_ref else []
     elif binding == "MISSING":
         observation_refs = [MISSING_OBSERVATION_REF]
-    else:
+    elif binding == "NONE":
         observation_refs = []
+    else:
+        raise ValueError(f"unknown observation_binding: {binding}")
 
     preimage = {
         "profile_id": CLAIM_PROFILE,

--- a/tools/generate_trustworthy_transition_vector.py
+++ b/tools/generate_trustworthy_transition_vector.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+"""Generate the three-record trustworthy-transition conformance vector.
+
+This generator intentionally does not read the checked-in fixture. It starts
+from published semantic inputs and emits canonical UTF-8 bytes, SHA-256 record
+references, claim/response digests, and independent verdict dimensions.
+
+The vector contains no floating-point values, so Python's sorted minimal JSON
+encoding is equivalent to RFC 8785 JCS for these inputs.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+AUTH_SCHEMA = "org.liminal.trustworthy-transition.authorization.v0.1"
+OBS_SCHEMA = "org.liminal.trustworthy-transition.observation.v0.1"
+INT_SCHEMA = "org.liminal.trustworthy-transition.response-integrity.v0.1"
+ACTION_PROFILE = "org.liminal.trustworthy-transition.action-identity.v0.1"
+BINDING_PROFILE = "org.liminal.trustworthy-transition.binding.v0.1"
+CLAIM_PROFILE = "org.liminal.trustworthy-transition.claim.v0.1"
+RESPONSE_PROFILE = "org.liminal.trustworthy-transition.response.v0.1"
+MISSING_OBSERVATION_REF = "sha256:" + ("f" * 64)
+
+BASE_ACTION_IDENTITY = {
+    "profile_id": ACTION_PROFILE,
+    "caller_id": "agent:deploy",
+    "tool_id": "tool:deploy",
+    "resource_scope": "tenant:acme/environment:production",
+}
+
+BASE_BINDING = {
+    "profile_id": BINDING_PROFILE,
+    "arguments": {
+        "artifact": "api@sha256:abc123",
+        "strategy": "rolling",
+    },
+    "policy_context": {
+        "policy_id": "deploy-policy",
+        "policy_version": "3",
+    },
+    "target_state_digest": "sha256:" + ("1" * 64),
+}
+
+BASE_RESULT = {
+    "status": "success",
+    "deployed_artifacts": 12,
+    "warnings": 2,
+    "release": "api@sha256:abc123",
+}
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def sha256_uri_text(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def digest_object(value: Any) -> str:
+    return sha256_uri_text(canonical_json(value))
+
+
+ACTION_DIGEST = digest_object(BASE_ACTION_IDENTITY)
+BINDING_DIGEST = digest_object(BASE_BINDING)
+
+
+def wrap_record(record: dict[str, Any]) -> dict[str, Any]:
+    canonical = canonical_json(record)
+    return {
+        "record": record,
+        "canonical_bytes_utf8": canonical,
+        "record_ref": sha256_uri_text(canonical),
+    }
+
+
+def make_authorization(case: dict[str, Any]) -> dict[str, Any]:
+    authorization = case["authorization"]
+    decision = authorization["decision"]
+    default_reasons = (
+        ["POLICY_MATCH", "FROZEN_CONTEXT_BOUND"]
+        if decision == "ALLOW"
+        else ["POLICY_DENY", "NO_EXECUTION_AUTHORITY"]
+    )
+    return wrap_record(
+        {
+            "schema": AUTH_SCHEMA,
+            "transition_id": "transition-001",
+            "subject_id": "agent:deploy",
+            "action_identity_profile": ACTION_PROFILE,
+            "action_identity_digest": ACTION_DIGEST,
+            "binding_profile": BINDING_PROFILE,
+            "binding_digest": BINDING_DIGEST,
+            "decision": decision,
+            "reason_codes": authorization.get("reason_codes", default_reasons),
+            "issued_at": "2030-01-01T00:00:00Z",
+            "expires_at": authorization.get(
+                "expires_at", "2030-01-01T00:05:00Z"
+            ),
+            "consumption_state": "UNCONSUMED",
+            "policy_ref": "policy:deploy/v3",
+        }
+    )
+
+
+def make_observation(
+    case: dict[str, Any],
+    authorization_ref: str,
+) -> dict[str, Any] | None:
+    observation = case["observation"]
+    if not observation["present"]:
+        return None
+
+    result = observation.get("result", BASE_RESULT)
+    return wrap_record(
+        {
+            "schema": OBS_SCHEMA,
+            "transition_id": "transition-001",
+            "subject_id": "agent:deploy",
+            "authorization_ref": authorization_ref,
+            "action_identity_digest": ACTION_DIGEST,
+            "binding_digest": BINDING_DIGEST,
+            "tool_call_id": "tool-call-001",
+            "execution_status": "EXECUTED",
+            "observed_at": observation.get(
+                "observed_at", "2030-01-01T00:04:00Z"
+            ),
+            "result": result,
+            "result_digest": digest_object(result),
+        }
+    )
+
+
+def claim_entry(
+    claim: dict[str, Any],
+    observation_ref: str | None,
+) -> dict[str, Any]:
+    binding = claim["observation_binding"]
+    if binding == "BASE":
+        observation_refs = [observation_ref] if observation_ref else []
+    elif binding == "MISSING":
+        observation_refs = [MISSING_OBSERVATION_REF]
+    else:
+        observation_refs = []
+
+    preimage = {
+        "profile_id": CLAIM_PROFILE,
+        "claim_text": claim["text"],
+    }
+    return {
+        "claim_id": claim["claim_id"],
+        "claim_text": claim["text"],
+        "claim_digest": digest_object(preimage),
+        "observation_refs": observation_refs,
+        "verdict": claim["verdict"],
+        "reason_code": claim["reason_code"],
+    }
+
+
+def make_integrity(
+    case: dict[str, Any],
+    authorization_ref: str,
+    observation_ref: str | None,
+) -> dict[str, Any]:
+    response = case["response"]
+    claims = [
+        claim_entry(claim, observation_ref)
+        for claim in response["claims"]
+    ]
+    response_preimage = {
+        "profile_id": RESPONSE_PROFILE,
+        "response_text": response["text"],
+    }
+
+    return wrap_record(
+        {
+            "schema": INT_SCHEMA,
+            "transition_id": "transition-001",
+            "subject_id": "agent:deploy",
+            "authorization_ref": authorization_ref,
+            "observation_refs": [observation_ref] if observation_ref else [],
+            "response_profile": RESPONSE_PROFILE,
+            "response_digest": digest_object(response_preimage),
+            "evaluated_at": response.get(
+                "evaluated_at", "2030-01-01T00:04:30Z"
+            ),
+            "claims": claims,
+            "overall_verdict": response["overall_verdict"],
+        }
+    )
+
+
+CASES: list[dict[str, Any]] = [
+    {
+        "case_id": "fully_supported",
+        "authorization": {"decision": "ALLOW", "current_state": "ACTIVE"},
+        "observation": {"present": True, "result": BASE_RESULT},
+        "response": {
+            "text": (
+                "Deployment completed successfully: 12 artifacts deployed "
+                "with 2 warnings."
+            ),
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "12 artifacts were deployed.",
+                    "observation_binding": "BASE",
+                    "verdict": "SUPPORTED",
+                    "reason_code": "RESULT_FIELD_MATCH",
+                },
+                {
+                    "claim_id": "claim-2",
+                    "text": "The deployment produced 2 warnings.",
+                    "observation_binding": "BASE",
+                    "verdict": "SUPPORTED",
+                    "reason_code": "RESULT_FIELD_MATCH",
+                },
+            ],
+            "overall_verdict": "VERIFIED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "ACTIVE",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "VERIFIED",
+            "expected_additional_side_effects": 1,
+        },
+    },
+    {
+        "case_id": "authorized_but_fabricated_result",
+        "authorization": {"decision": "ALLOW", "current_state": "ACTIVE"},
+        "observation": {"present": True, "result": BASE_RESULT},
+        "response": {
+            "text": "Deployment completed successfully: 20 artifacts deployed.",
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "20 artifacts were deployed.",
+                    "observation_binding": "BASE",
+                    "verdict": "CONTRADICTED",
+                    "reason_code": "RESULT_VALUE_MISMATCH",
+                }
+            ],
+            "overall_verdict": "FAILED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "ACTIVE",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "FAILED",
+            "expected_additional_side_effects": 1,
+        },
+    },
+    {
+        "case_id": "authorized_but_count_drift",
+        "authorization": {"decision": "ALLOW", "current_state": "ACTIVE"},
+        "observation": {"present": True, "result": BASE_RESULT},
+        "response": {
+            "text": "Deployment completed: 13 artifacts deployed.",
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "13 artifacts were deployed.",
+                    "observation_binding": "BASE",
+                    "verdict": "CONTRADICTED",
+                    "reason_code": "COUNT_MISMATCH",
+                }
+            ],
+            "overall_verdict": "FAILED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "ACTIVE",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "FAILED",
+            "expected_additional_side_effects": 1,
+        },
+    },
+    {
+        "case_id": "authorized_but_missing_citation_binding",
+        "authorization": {"decision": "ALLOW", "current_state": "ACTIVE"},
+        "observation": {"present": True, "result": BASE_RESULT},
+        "response": {
+            "text": (
+                "Deployment completed: 12 artifacts deployed. "
+                "See observation citation."
+            ),
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "12 artifacts were deployed.",
+                    "observation_binding": "MISSING",
+                    "verdict": "UNVERIFIABLE",
+                    "reason_code": "OBSERVATION_REFERENCE_MISSING",
+                }
+            ],
+            "overall_verdict": "FAILED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "ACTIVE",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "FAILED",
+            "expected_additional_side_effects": 1,
+        },
+    },
+    {
+        "case_id": "blocked_but_claimed_executed",
+        "authorization": {
+            "decision": "DENY",
+            "current_state": "DENIED",
+            "reason_codes": ["POLICY_DENY", "NO_EXECUTION_AUTHORITY"],
+        },
+        "observation": {"present": False},
+        "response": {
+            "text": "Deployment completed successfully.",
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "The deployment tool executed successfully.",
+                    "observation_binding": "NONE",
+                    "verdict": "CONTRADICTED",
+                    "reason_code": (
+                        "AUTHORIZATION_DENIED_AND_NO_OBSERVATION"
+                    ),
+                }
+            ],
+            "overall_verdict": "FAILED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "DENIED",
+                "current_state": "DENIED",
+            },
+            "execution": "NOT_OBSERVED",
+            "integrity": "FAILED",
+            "expected_additional_side_effects": 0,
+        },
+    },
+    {
+        "case_id": "stale_authorization_honest_response",
+        "authorization": {
+            "decision": "ALLOW",
+            "current_state": "EXPIRED_AT_REPORT",
+            "expires_at": "2030-01-01T00:05:00Z",
+        },
+        "observation": {
+            "present": True,
+            "observed_at": "2030-01-01T00:04:00Z",
+            "result": BASE_RESULT,
+        },
+        "response": {
+            "evaluated_at": "2030-01-01T00:06:00Z",
+            "text": (
+                "Deployment completed before authorization expiry: "
+                "12 artifacts deployed."
+            ),
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": (
+                        "12 artifacts were deployed before authorization expired."
+                    ),
+                    "observation_binding": "BASE",
+                    "verdict": "SUPPORTED",
+                    "reason_code": "OBSERVED_BEFORE_EXPIRY",
+                }
+            ],
+            "overall_verdict": "VERIFIED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "EXPIRED_AT_REPORT",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "VERIFIED",
+            "expected_additional_side_effects": 1,
+        },
+    },
+    {
+        "case_id": "honest_authorization_false_response",
+        "authorization": {"decision": "ALLOW", "current_state": "ACTIVE"},
+        "observation": {"present": True, "result": BASE_RESULT},
+        "response": {
+            "text": (
+                "Deployment completed: 12 artifacts deployed with zero warnings."
+            ),
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "12 artifacts were deployed.",
+                    "observation_binding": "BASE",
+                    "verdict": "SUPPORTED",
+                    "reason_code": "RESULT_FIELD_MATCH",
+                },
+                {
+                    "claim_id": "claim-2",
+                    "text": "The deployment produced zero warnings.",
+                    "observation_binding": "BASE",
+                    "verdict": "CONTRADICTED",
+                    "reason_code": "RESULT_VALUE_MISMATCH",
+                },
+            ],
+            "overall_verdict": "FAILED",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "ACTIVE",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "FAILED",
+            "expected_additional_side_effects": 1,
+        },
+    },
+    {
+        "case_id": "mixed_supported_and_unverifiable_claims",
+        "authorization": {"decision": "ALLOW", "current_state": "ACTIVE"},
+        "observation": {"present": True, "result": BASE_RESULT},
+        "response": {
+            "text": (
+                "Deployment completed: 12 artifacts deployed. "
+                "No user traffic was affected."
+            ),
+            "claims": [
+                {
+                    "claim_id": "claim-1",
+                    "text": "12 artifacts were deployed.",
+                    "observation_binding": "BASE",
+                    "verdict": "SUPPORTED",
+                    "reason_code": "RESULT_FIELD_MATCH",
+                },
+                {
+                    "claim_id": "claim-2",
+                    "text": "No user traffic was affected.",
+                    "observation_binding": "NONE",
+                    "verdict": "UNVERIFIABLE",
+                    "reason_code": "NO_SUPPORTING_OBSERVATION",
+                },
+            ],
+            "overall_verdict": "PARTIAL",
+        },
+        "expected": {
+            "authority": {
+                "verdict": "VALID_AT_EXECUTION",
+                "current_state": "ACTIVE",
+            },
+            "execution": "OBSERVED_EXECUTED",
+            "integrity": "PARTIAL",
+            "expected_additional_side_effects": 1,
+        },
+    },
+]
+
+
+def derive_case(case: dict[str, Any]) -> dict[str, Any]:
+    derived_case = copy.deepcopy(case)
+    authorization = make_authorization(case)
+    observation = make_observation(case, authorization["record_ref"])
+    observation_ref = observation["record_ref"] if observation else None
+    integrity = make_integrity(
+        case,
+        authorization["record_ref"],
+        observation_ref,
+    )
+
+    derived_case["derived"] = {
+        "authorization_ref": authorization["record_ref"],
+        "observation_ref": observation_ref,
+        "response_integrity_ref": integrity["record_ref"],
+        "response_digest": integrity["record"]["response_digest"],
+        "claim_digests": [
+            claim["claim_digest"] for claim in integrity["record"]["claims"]
+        ],
+        "claim_observation_refs": [
+            claim["observation_refs"] for claim in integrity["record"]["claims"]
+        ],
+    }
+    return derived_case
+
+
+def build_fixture() -> dict[str, Any]:
+    base_authorization = make_authorization(CASES[0])
+    base_observation = make_observation(
+        CASES[0],
+        base_authorization["record_ref"],
+    )
+    assert base_observation is not None
+
+    return {
+        "fixture_version": "0.1",
+        "revision": "2026-06-29.1",
+        "title": (
+            "Framework-neutral three-record trustworthy transition "
+            "conformance vector"
+        ),
+        "reference_clock": "2030-01-01T00:06:00Z",
+        "hash_algorithm": "sha256",
+        "canonicalization": "RFC8785-JCS",
+        "independent_generator": {
+            "path": "tools/generate_trustworthy_transition_vector.py",
+            "reads_fixture": False,
+        },
+        "profiles": {
+            "action_identity": ACTION_PROFILE,
+            "binding": BINDING_PROFILE,
+            "authorization_record": AUTH_SCHEMA,
+            "observation_record": OBS_SCHEMA,
+            "response_integrity_record": INT_SCHEMA,
+            "claim": CLAIM_PROFILE,
+            "response": RESPONSE_PROFILE,
+        },
+        "record_reference_rule": (
+            "record_ref = sha256(RFC8785-JCS(record))"
+        ),
+        "required_join_keys": [
+            "transition_id",
+            "subject_id",
+            "authorization_ref",
+            "action_identity_digest",
+            "binding_digest",
+            "observation_refs",
+        ],
+        "base_preimages": {
+            "action_identity": BASE_ACTION_IDENTITY,
+            "canonical_action_identity_bytes_utf8": canonical_json(
+                BASE_ACTION_IDENTITY
+            ),
+            "action_identity_digest": ACTION_DIGEST,
+            "binding": BASE_BINDING,
+            "canonical_binding_bytes_utf8": canonical_json(BASE_BINDING),
+            "binding_digest": BINDING_DIGEST,
+        },
+        "base_records": {
+            "authorization_record": base_authorization,
+            "observation_record": base_observation,
+        },
+        "verdict_taxonomy": {
+            "authority_verdicts": [
+                "VALID_AT_EXECUTION",
+                "DENIED",
+                "DEFERRED",
+                "INVALID",
+                "MISSING",
+            ],
+            "authority_current_states": [
+                "ACTIVE",
+                "DENIED",
+                "DEFERRED",
+                "EXPIRED_AT_REPORT",
+                "CONSUMED_AT_REPORT",
+                "INVALID",
+                "MISSING",
+            ],
+            "execution_verdicts": [
+                "OBSERVED_EXECUTED",
+                "OBSERVED_BLOCKED",
+                "NOT_OBSERVED",
+                "INVALID_BINDING",
+            ],
+            "claim_verdicts": [
+                "SUPPORTED",
+                "CONTRADICTED",
+                "UNVERIFIABLE",
+                "OUT_OF_SCOPE",
+            ],
+            "integrity_verdicts": [
+                "VERIFIED",
+                "FAILED",
+                "PARTIAL",
+                "NOT_EVALUATED",
+            ],
+        },
+        "cases": [derive_case(case) for case in CASES],
+        "invariants": [
+            (
+                "Authorization, execution observation, and response integrity "
+                "are independent verdict dimensions."
+            ),
+            (
+                "A valid authorization cannot make a contradicted response "
+                "claim pass."
+            ),
+            (
+                "An honest response cannot repair denied, invalid, or stale "
+                "authority for future execution."
+            ),
+            (
+                "Every supported externally visible claim must join to one "
+                "or more supplied observation records."
+            ),
+            (
+                "Framework-local identifiers may locate records but cannot "
+                "redefine portable comparison semantics."
+            ),
+            (
+                "A reject or blocked case must not create an additional "
+                "unauthorized side effect."
+            ),
+        ],
+    }
+
+
+def main() -> None:
+    print(json.dumps(build_fixture(), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_trustworthy_transition_vector.py
+++ b/tools/verify_trustworthy_transition_vector.py
@@ -195,6 +195,64 @@ def verify_generated_evidence(generated: dict[str, Any]) -> None:
                 f"{case_id}.expected.authority must be an object"
             )
 
+        if observation is None:
+            expected_execution = "NOT_OBSERVED"
+        else:
+            status = observation["record"]["execution_status"]
+            if status == "EXECUTED":
+                expected_execution = "OBSERVED_EXECUTED"
+            elif status in {"BLOCKED", "ERRORED", "REFUSED"}:
+                expected_execution = "OBSERVED_BLOCKED"
+            else:
+                raise FixtureVerificationError(
+                    f"{case_id} unknown execution status: {status}"
+                )
+        if expected.get("execution") != expected_execution:
+            raise FixtureVerificationError(
+                f"{case_id} execution expectation mismatch"
+            )
+
+        authorization_record = authorization["record"]
+        if authorization_record["decision"] == "DENY":
+            expected_authority = {
+                "verdict": "DENIED",
+                "current_state": "DENIED",
+            }
+        elif authorization_record["decision"] == "ALLOW":
+            if observation is None:
+                raise FixtureVerificationError(
+                    f"{case_id} allowed case must carry an observation"
+                )
+            observed_at = observation["record"]["observed_at"]
+            if not (
+                authorization_record["issued_at"]
+                <= observed_at
+                <= authorization_record["expires_at"]
+            ):
+                expected_authority = {
+                    "verdict": "INVALID",
+                    "current_state": "INVALID",
+                }
+            else:
+                current_state = (
+                    "EXPIRED_AT_REPORT"
+                    if integrity["record"]["evaluated_at"]
+                    > authorization_record["expires_at"]
+                    else "ACTIVE"
+                )
+                expected_authority = {
+                    "verdict": "VALID_AT_EXECUTION",
+                    "current_state": current_state,
+                }
+        else:
+            raise FixtureVerificationError(
+                f"{case_id} unknown authority decision"
+            )
+        if authority != expected_authority:
+            raise FixtureVerificationError(
+                f"{case_id} authority expectation mismatch"
+            )
+
         if authority.get("verdict") == "DENIED":
             if expected.get("expected_additional_side_effects") != 0:
                 raise FixtureVerificationError(

--- a/tools/verify_trustworthy_transition_vector.py
+++ b/tools/verify_trustworthy_transition_vector.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Verify the checked-in three-record trustworthy-transition fixture."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from generate_trustworthy_transition_vector import (
+    build_fixture,
+    canonical_json,
+    make_authorization,
+    make_integrity,
+    make_observation,
+    sha256_uri_text,
+)
+
+
+class FixtureVerificationError(ValueError):
+    """Raised when the fixture violates the published profile."""
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise FixtureVerificationError(f"cannot read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise FixtureVerificationError(
+            f"invalid JSON in {path}: {error.msg}"
+        ) from error
+
+    if not isinstance(value, dict):
+        raise FixtureVerificationError("fixture root must be an object")
+    return value
+
+
+def semantic_view(generated: dict[str, Any]) -> dict[str, Any]:
+    """Remove independently derived evidence from generator output."""
+    view = copy.deepcopy(generated)
+    view.pop("base_records", None)
+    for case in view.get("cases", []):
+        case.pop("derived", None)
+    return view
+
+
+def verify_wrapper(wrapper: dict[str, Any], *, label: str) -> None:
+    if set(wrapper) != {"record", "canonical_bytes_utf8", "record_ref"}:
+        raise FixtureVerificationError(
+            f"{label} must contain exactly record, canonical_bytes_utf8, record_ref"
+        )
+
+    record = wrapper["record"]
+    if not isinstance(record, dict):
+        raise FixtureVerificationError(f"{label}.record must be an object")
+
+    canonical = canonical_json(record)
+    if wrapper["canonical_bytes_utf8"] != canonical:
+        raise FixtureVerificationError(f"{label} canonical bytes mismatch")
+
+    if wrapper["record_ref"] != sha256_uri_text(canonical):
+        raise FixtureVerificationError(f"{label} record reference mismatch")
+
+
+def verify_generated_evidence(generated: dict[str, Any]) -> None:
+    base_records = generated.get("base_records")
+    if not isinstance(base_records, dict):
+        raise FixtureVerificationError("generator omitted base_records")
+
+    base_authorization = base_records.get("authorization_record")
+    base_observation = base_records.get("observation_record")
+    if not isinstance(base_authorization, dict) or not isinstance(
+        base_observation, dict
+    ):
+        raise FixtureVerificationError(
+            "generator must emit base authorization and observation records"
+        )
+
+    verify_wrapper(base_authorization, label="base authorization_record")
+    verify_wrapper(base_observation, label="base observation_record")
+
+    if (
+        base_observation["record"]["authorization_ref"]
+        != base_authorization["record_ref"]
+    ):
+        raise FixtureVerificationError(
+            "base observation does not join to base authorization"
+        )
+
+    result_digest = sha256_uri_text(
+        canonical_json(base_observation["record"]["result"])
+    )
+    if base_observation["record"]["result_digest"] != result_digest:
+        raise FixtureVerificationError("base observation result digest mismatch")
+
+    seen: set[str] = set()
+    for case in generated.get("cases", []):
+        case_id = case.get("case_id")
+        if not isinstance(case_id, str) or not case_id:
+            raise FixtureVerificationError("case_id must be non-empty")
+        if case_id in seen:
+            raise FixtureVerificationError(f"duplicate case_id: {case_id}")
+        seen.add(case_id)
+
+        derived = case.get("derived")
+        expected = case.get("expected")
+        response = case.get("response")
+        if not all(
+            isinstance(value, dict)
+            for value in (derived, expected, response)
+        ):
+            raise FixtureVerificationError(
+                f"{case_id} missing derived, expected, or response object"
+            )
+
+        authorization = make_authorization(case)
+        observation = make_observation(case, authorization["record_ref"])
+        observation_ref = observation["record_ref"] if observation else None
+        integrity = make_integrity(
+            case,
+            authorization["record_ref"],
+            observation_ref,
+        )
+
+        verify_wrapper(
+            authorization,
+            label=f"{case_id}.authorization_record",
+        )
+        if observation is not None:
+            verify_wrapper(
+                observation,
+                label=f"{case_id}.observation_record",
+            )
+            if (
+                observation["record"]["authorization_ref"]
+                != authorization["record_ref"]
+            ):
+                raise FixtureVerificationError(
+                    f"{case_id} observation authorization join mismatch"
+                )
+            if (
+                observation["record"]["action_identity_digest"]
+                != authorization["record"]["action_identity_digest"]
+                or observation["record"]["binding_digest"]
+                != authorization["record"]["binding_digest"]
+            ):
+                raise FixtureVerificationError(
+                    f"{case_id} observation action/binding mismatch"
+                )
+
+        verify_wrapper(
+            integrity,
+            label=f"{case_id}.response_integrity_record",
+        )
+        if (
+            integrity["record"]["authorization_ref"]
+            != authorization["record_ref"]
+        ):
+            raise FixtureVerificationError(
+                f"{case_id} integrity authorization join mismatch"
+            )
+
+        expected_derived = {
+            "authorization_ref": authorization["record_ref"],
+            "observation_ref": observation_ref,
+            "response_integrity_ref": integrity["record_ref"],
+            "response_digest": integrity["record"]["response_digest"],
+            "claim_digests": [
+                claim["claim_digest"]
+                for claim in integrity["record"]["claims"]
+            ],
+            "claim_observation_refs": [
+                claim["observation_refs"]
+                for claim in integrity["record"]["claims"]
+            ],
+        }
+        if derived != expected_derived:
+            raise FixtureVerificationError(
+                f"{case_id} independently derived evidence mismatch"
+            )
+
+        claims = integrity["record"]["claims"]
+        for claim in claims:
+            if claim["verdict"] == "SUPPORTED" and not claim["observation_refs"]:
+                raise FixtureVerificationError(
+                    f"{case_id}.{claim['claim_id']} supported without observation"
+                )
+
+        authority = expected.get("authority")
+        if not isinstance(authority, dict):
+            raise FixtureVerificationError(
+                f"{case_id}.expected.authority must be an object"
+            )
+
+        if authority.get("verdict") == "DENIED":
+            if expected.get("expected_additional_side_effects") != 0:
+                raise FixtureVerificationError(
+                    f"{case_id} denied authority must expect zero side effects"
+                )
+            if observation is not None:
+                raise FixtureVerificationError(
+                    f"{case_id} denied case must not carry an observation"
+                )
+
+        if (
+            integrity["record"]["overall_verdict"]
+            != expected.get("integrity")
+        ):
+            raise FixtureVerificationError(
+                f"{case_id} integrity expectation mismatch"
+            )
+
+
+def verify_fixture(path: Path) -> None:
+    actual = load_fixture(path)
+    generated = build_fixture()
+
+    if actual != semantic_view(generated):
+        raise FixtureVerificationError(
+            "checked-in semantic fixture differs from the independent generator"
+        )
+
+    verify_generated_evidence(generated)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "fixture",
+        nargs="?",
+        type=Path,
+        default=Path(
+            "fixtures/"
+            "trustworthy-transition-three-record-conformance-v0.1.json"
+        ),
+    )
+    args = parser.parse_args()
+
+    verify_fixture(args.fixture)
+    print(
+        "OK: semantic fixture matches the independent generator; "
+        "record digests and joins are valid"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the first canonical artifact for #108: a framework-neutral three-record trustworthy-transition profile joining:

- `authorization_record`;
- `observation_record`;
- `response_integrity_record`.

The records retain independent authority, execution, and claim-integrity verdicts instead of collapsing them into one generic success/failure state.

## Added

- `docs/interop/TRUSTWORTHY_TRANSITION_THREE_RECORD_PROFILE_V0_1.md`
- `fixtures/trustworthy-transition-three-record-conformance-v0.1.json`
- `tools/generate_trustworthy_transition_vector.py`
- `tools/verify_trustworthy_transition_vector.py`

## Conformance cases

1. fully supported transition;
2. authorized but fabricated result;
3. count drift;
4. missing citation/observation binding;
5. denied action claimed as executed;
6. honest report after authority expires;
7. valid authorization with a contradicted response claim;
8. mixed supported and unverifiable claims.

## Verification design

The checked-in fixture contains the portable semantic inputs and expected verdicts. The independent standard-library generator does not read that fixture; it derives:

- RFC 8785-compatible canonical bytes for the supported value domain;
- SHA-256 action and binding digests;
- authorization, observation, and response-integrity record references;
- result, claim, and response digests;
- observation joins for every claim.

The verifier compares the semantic fixture against the independent generator and then validates record references, result digests, authorization/observation joins, supported-claim evidence requirements, and zero-side-effect behavior for denied execution.

## Local validation

```bash
python tools/verify_trustworthy_transition_vector.py
```

Observed locally:

```text
OK: semantic fixture matches the independent generator; record digests and joins are valid
```

## Boundaries

- Response integrity is not a second authorization gate.
- A valid authorization cannot make a false response claim pass.
- An honest response cannot reactivate expired authority.
- Framework-local identifiers do not redefine portable comparison semantics.
- This profile does not claim production security, attestation trust, policy correctness, or uncompromised observation sources.

## Follow-up ecosystem tasks

- ibex-agent-verification#56
- LTP#480
- LS#767
- ProofPath#166
- PythiaLabs#204
- Causal-Memory-Layer#163
- LiminalDB#87

Relates to #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interoperability profile and conformance fixture for a three-record transition workflow.
  * Added tools to generate and verify the fixture with consistent reference and digest handling.
  * Included multiple end-to-end scenarios covering supported, denied, missing, stale, and mismatched cases.

* **Documentation**
  * Added detailed guidance on expected record structure, validation order, invariants, and verdict categories for interoperability testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->