### PR TITLE
feat: add ecosystem compatibility pack v0.1

### DIFF
--- a/.github/workflows/trustworthy-transition-conformance.yml
+++ b/.github/workflows/trustworthy-transition-conformance.yml
@@ -1,0 +1,46 @@
+name: Trustworthy Transition Conformance
+
+on:
+  pull_request:
+    paths:
+      - "docs/interop/TRUSTWORTHY_TRANSITION_*"
+      - "fixtures/trustworthy-transition-*"
+      - "tools/*trustworthy_transition*"
+      - ".github/workflows/trustworthy-transition-conformance.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/interop/TRUSTWORTHY_TRANSITION_*"
+      - "fixtures/trustworthy-transition-*"
+      - "tools/*trustworthy_transition*"
+      - ".github/workflows/trustworthy-transition-conformance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify canonical three-record vector
+        run: python3 tools/verify_trustworthy_transition_vector.py
+
+      - name: Verify ecosystem compatibility pack
+        run: |
+          mkdir -p artifacts
+          python3 tools/verify_trustworthy_transition_ecosystem.py \
+            --output artifacts/trustworthy-transition-ecosystem-receipt.json
+
+      - name: Upload compatibility receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: trustworthy-transition-ecosystem-receipt
+          path: artifacts/trustworthy-transition-ecosystem-receipt.json
+          if-no-files-found: error

--- a/docs/interop/TRUSTWORTHY_TRANSITION_ECOSYSTEM_COMPATIBILITY_V0_1.md
+++ b/docs/interop/TRUSTWORTHY_TRANSITION_ECOSYSTEM_COMPATIBILITY_V0_1.md
@@ -1,0 +1,189 @@
+# Trustworthy Transition Ecosystem Compatibility Pack v0.1
+
+**Status:** Draft interoperability pack  
+**Canonical profile:** `org.liminal.trustworthy-transition.three-record.v0.1`  
+**Tracking issue:** [Liminal #108](https://github.com/safal207/Liminal/issues/108)
+
+## Purpose
+
+The canonical three-record profile defines the portable contract. This pack
+checks whether concrete ecosystem implementations can be normalized into that
+contract without collapsing their local semantics.
+
+The first pinned implementation set is:
+
+| Boundary | Implementation | PR |
+|---|---|---|
+| Pre-execution authority | ProofPath | [#167](https://github.com/safal207/ProofPath/pull/167) |
+| Pre-execution authority | PythiaLabs | [#205](https://github.com/safal207/pythiaLabs/pull/205) |
+| Manifest-bound observation/evidence | ibex-agent-verification | [#58](https://github.com/safal207/ibex-agent-verification/pull/58) |
+| Joined response-claim verification | LTP | [#481](https://github.com/safal207/L-THREAD-Liminal-Thread-Secure-Protocol-LTP-/pull/481) |
+
+Each registry entry pins:
+
+- repository;
+- pull request;
+- exact head commit SHA;
+- implementation artifact path;
+- local profile identifier;
+- owned lifecycle roles;
+- local-to-canonical vocabulary mappings.
+
+The pack is intentionally offline and deterministic. It does not fetch mutable
+remote branches during CI.
+
+## Files
+
+- Fixture: [`fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json`](../../fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json)
+- Verifier: [`tools/verify_trustworthy_transition_ecosystem.py`](../../tools/verify_trustworthy_transition_ecosystem.py)
+
+Run:
+
+```bash
+python3 tools/verify_trustworthy_transition_vector.py
+python3 tools/verify_trustworthy_transition_ecosystem.py
+```
+
+Generate a machine-readable receipt:
+
+```bash
+python3 tools/verify_trustworthy_transition_ecosystem.py \
+  --output artifacts/trustworthy-transition-ecosystem-receipt.json
+```
+
+## What is normalized
+
+### Authority decisions
+
+Provider-local decisions are mapped into:
+
+```text
+ALLOW
+DENY
+DEFER
+```
+
+The authority dimension remains more descriptive than the decision itself:
+
+```text
+VALID
+DENIED
+PENDING
+EXPIRED
+EXPIRED_AT_REPORT
+CONSUMED
+REVALIDATION_REQUIRED
+NOT_EVALUATED
+```
+
+This preserves distinctions such as consumed authority and honest reporting
+after authority expires.
+
+### Execution observations
+
+Runtime-local execution statuses are mapped into:
+
+```text
+OBSERVED_EXECUTED
+OBSERVED_BLOCKED
+OBSERVED_ERRORED
+NOT_OBSERVED
+```
+
+### Response integrity
+
+Claim verifiers map their overall result into:
+
+```text
+VERIFIED
+FAILED
+PARTIAL
+NOT_EVALUATED
+```
+
+The LTP adapter also exposes the evidence level:
+
+```text
+TEXT_HEURISTIC
+OBSERVATION_JOINED
+FULL_LIFECYCLE_JOINED
+```
+
+## Required joins
+
+Authorization to observation:
+
+```text
+transition_id
+subject_id
+authorization_ref
+action_identity_digest
+binding_digest
+```
+
+Observation to response integrity:
+
+```text
+transition_id
+subject_id
+authorization_ref
+observation_refs
+```
+
+Framework-local identifiers may be retained as metadata, but they cannot replace
+or redefine these portable keys.
+
+## Compatibility cases
+
+The pack currently proves these independent combinations:
+
+1. ProofPath authority + ibex observation + LTP supported response;
+2. PythiaLabs block + no execution + false execution claim;
+3. ProofPath authority expired at report time + historical execution + honest response;
+4. PythiaLabs valid authority + observed execution + false response;
+5. ProofPath consumed replay authority + no execution + honest response;
+6. ibex observation + LTP count-drift failure without imported authority;
+7. PythiaLabs valid authority + observed execution + mixed partial response.
+
+These cases deliberately distinguish:
+
+```text
+VALID + OBSERVED_EXECUTED + FAILED
+EXPIRED_AT_REPORT + OBSERVED_EXECUTED + VERIFIED
+CONSUMED + NOT_OBSERVED + VERIFIED
+NOT_EVALUATED + OBSERVED_EXECUTED + FAILED
+```
+
+## Side-effect rule
+
+`expected_additional_side_effects` is derived independently:
+
+- `1` only for `VALID + OBSERVED_EXECUTED`;
+- `0` for denied, deferred, expired, consumed, revalidation-required, or
+  authority-not-evaluated cases.
+
+`EXPIRED_AT_REPORT + OBSERVED_EXECUTED` may describe a legitimate historical
+execution, but it still permits zero new side effects at report time.
+
+## CI behavior
+
+The workflow runs both layers:
+
+1. canonical semantic fixture and independent generator verification;
+2. pinned ecosystem registry, mapping, role, join, and dimension verification.
+
+A repository PR changing its head SHA or portable vocabulary requires an
+explicit registry update. This makes compatibility drift visible instead of
+silently following a mutable branch.
+
+## Boundary
+
+This pack proves the consistency of checked-in metadata and mappings. It does
+not:
+
+- fetch or attest the current remote PR state;
+- replace each repository's unit tests, CI, CodeRabbit, or mandatory Codex review;
+- prove policy correctness or observation-source trust;
+- allow one component's success to repair another dimension's failure.
+
+The repository-specific PRs remain draft until their own review gates pass.

--- a/docs/interop/TRUSTWORTHY_TRANSITION_ECOSYSTEM_COMPATIBILITY_V0_1.md
+++ b/docs/interop/TRUSTWORTHY_TRANSITION_ECOSYSTEM_COMPATIBILITY_V0_1.md
@@ -141,7 +141,7 @@ The pack currently proves these independent combinations:
 2. PythiaLabs block + no execution + false execution claim;
 3. ProofPath authority expired at report time + historical execution + honest response;
 4. PythiaLabs valid authority + observed execution + false response;
-5. ProofPath consumed replay authority + no execution + honest response;
+5. ProofPath consumed replay authority + observed runtime block + honest response;
 6. ibex observation + LTP count-drift failure without imported authority;
 7. PythiaLabs valid authority + observed execution + mixed partial response.
 
@@ -150,7 +150,7 @@ These cases deliberately distinguish:
 ```text
 VALID + OBSERVED_EXECUTED + FAILED
 EXPIRED_AT_REPORT + OBSERVED_EXECUTED + VERIFIED
-CONSUMED + NOT_OBSERVED + VERIFIED
+CONSUMED + OBSERVED_BLOCKED + VERIFIED
 NOT_EVALUATED + OBSERVED_EXECUTED + FAILED
 ```
 

--- a/fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json
+++ b/fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json
@@ -233,17 +233,18 @@
       "local_outcomes": {
         "authorization_decision": "BLOCK",
         "authorization_state": "CONSUMED",
-        "execution_status": "NONE",
+        "execution_status": "BLOCKED",
         "integrity_verdict": "VERIFIED",
         "verification_level": "FULL_LIFECYCLE_JOINED"
       },
       "required_record_roles": [
         "authorization_record",
+        "observation_record",
         "response_integrity_record"
       ],
       "expected": {
         "authority": "CONSUMED",
-        "execution": "NOT_OBSERVED",
+        "execution": "OBSERVED_BLOCKED",
         "response_integrity": "VERIFIED",
         "expected_additional_side_effects": 0
       }

--- a/fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json
+++ b/fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json
@@ -1,0 +1,303 @@
+{
+  "schema_version": 1,
+  "profile": "org.liminal.trustworthy-transition.ecosystem-compatibility.v0.1",
+  "canonical_profile": "org.liminal.trustworthy-transition.three-record.v0.1",
+  "implementations": [
+    {
+      "implementation_id": "proofpath.authorization.v0.1",
+      "repository": "safal207/ProofPath",
+      "pull_request": 167,
+      "head_sha": "e8bd2641752282c7eea2cfe4650246a77df2bfbc",
+      "artifact_path": "scripts/check_authorization_record_export.py",
+      "local_profile": "org.proofpath.authorization-export.v0.1",
+      "roles": ["AUTHORIZATION_PRODUCER"],
+      "canonical_records": ["authorization_record"],
+      "decision_map": {
+        "ACCEPT": "ALLOW",
+        "HOLD": "DEFER",
+        "BLOCK": "DENY",
+        "REJECT": "DENY"
+      },
+      "authority_state_map": {
+        "ACTIVE": "VALID",
+        "PENDING_APPROVAL": "PENDING",
+        "EXPIRED": "EXPIRED",
+        "EXPIRED_AT_REPORT": "EXPIRED_AT_REPORT",
+        "CONSUMED": "CONSUMED",
+        "BLOCKED": "DENIED"
+      }
+    },
+    {
+      "implementation_id": "pythialabs.authorization.v0.1",
+      "repository": "safal207/pythiaLabs",
+      "pull_request": 205,
+      "head_sha": "dbe5668164f7650ae0ce7f9fd2f2d0f14d92ea71",
+      "artifact_path": "scripts/check_pythialabs_authorization_export.py",
+      "local_profile": "org.pythialabs.authorization-export.v0.1",
+      "roles": ["AUTHORIZATION_PRODUCER"],
+      "canonical_records": ["authorization_record"],
+      "decision_map": {
+        "ALLOW": "ALLOW",
+        "BLOCK": "DENY",
+        "ESCALATE": "DEFER"
+      },
+      "authority_state_map": {
+        "ACTIVE": "VALID",
+        "BLOCKED": "DENIED",
+        "EXPIRED": "EXPIRED",
+        "REVALIDATION_REQUIRED": "REVALIDATION_REQUIRED"
+      }
+    },
+    {
+      "implementation_id": "ibex.manifest-observation.v0.1",
+      "repository": "safal207/ibex-agent-verification",
+      "pull_request": 58,
+      "head_sha": "4e73022c01c3bd0f458eab2fad0d0b351b5dfb58",
+      "artifact_path": "scripts/proofqa_response_integrity.py",
+      "local_profile": "org.ibex.response-integrity.v0.1",
+      "roles": ["OBSERVATION_BINDER", "INTEGRITY_EVIDENCE_BINDER"],
+      "canonical_records": ["observation_record", "response_integrity_record"],
+      "execution_status_map": {
+        "EXECUTED": "OBSERVED_EXECUTED",
+        "BLOCKED": "OBSERVED_BLOCKED",
+        "REFUSED": "OBSERVED_BLOCKED",
+        "ERRORED": "OBSERVED_ERRORED",
+        "NONE": "NOT_OBSERVED"
+      },
+      "integrity_verdict_map": {
+        "VERIFIED": "VERIFIED",
+        "FAILED": "FAILED",
+        "PARTIAL": "PARTIAL",
+        "NOT_EVALUATED": "NOT_EVALUATED"
+      }
+    },
+    {
+      "implementation_id": "ltp.lifecycle-integrity.v0.1",
+      "repository": "safal207/L-THREAD-Liminal-Thread-Secure-Protocol-LTP-",
+      "pull_request": 481,
+      "head_sha": "b1fcf43977a2de5cd21b84887d6dcdc1d451acd1",
+      "artifact_path": "tools/lifecycle-integrity/verify.ts",
+      "local_profile": "org.ltp.lifecycle-integrity.v0.1",
+      "roles": ["CLAIM_VERIFIER", "LIFECYCLE_JOIN_VERIFIER"],
+      "canonical_records": ["response_integrity_record"],
+      "verification_level_map": {
+        "TEXT_HEURISTIC": "TEXT_HEURISTIC",
+        "OBSERVATION_JOINED": "OBSERVATION_JOINED",
+        "FULL_LIFECYCLE_JOINED": "FULL_LIFECYCLE_JOINED"
+      },
+      "integrity_verdict_map": {
+        "VERIFIED": "VERIFIED",
+        "FAILED": "FAILED",
+        "PARTIAL": "PARTIAL",
+        "NOT_EVALUATED": "NOT_EVALUATED"
+      }
+    }
+  ],
+  "join_contract": {
+    "authorization_to_observation": [
+      "transition_id",
+      "subject_id",
+      "authorization_ref",
+      "action_identity_digest",
+      "binding_digest"
+    ],
+    "observation_to_integrity": [
+      "transition_id",
+      "subject_id",
+      "authorization_ref",
+      "observation_refs"
+    ],
+    "independent_dimensions": [
+      "authority",
+      "execution",
+      "response_integrity"
+    ],
+    "claim_verdicts": [
+      "SUPPORTED",
+      "CONTRADICTED",
+      "UNVERIFIABLE",
+      "OUT_OF_SCOPE"
+    ]
+  },
+  "cases": [
+    {
+      "case_id": "proofpath_ibex_ltp_fully_supported",
+      "participants": {
+        "authorization": "proofpath.authorization.v0.1",
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": "ACCEPT",
+        "authorization_state": "ACTIVE",
+        "execution_status": "EXECUTED",
+        "integrity_verdict": "VERIFIED",
+        "verification_level": "FULL_LIFECYCLE_JOINED"
+      },
+      "required_record_roles": [
+        "authorization_record",
+        "observation_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "VALID",
+        "execution": "OBSERVED_EXECUTED",
+        "response_integrity": "VERIFIED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "pythialabs_blocked_claimed_executed",
+      "participants": {
+        "authorization": "pythialabs.authorization.v0.1",
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": "BLOCK",
+        "authorization_state": "BLOCKED",
+        "execution_status": "NONE",
+        "integrity_verdict": "FAILED",
+        "verification_level": "FULL_LIFECYCLE_JOINED"
+      },
+      "required_record_roles": [
+        "authorization_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "DENIED",
+        "execution": "NOT_OBSERVED",
+        "response_integrity": "FAILED",
+        "expected_additional_side_effects": 0
+      }
+    },
+    {
+      "case_id": "proofpath_expired_at_report_honest",
+      "participants": {
+        "authorization": "proofpath.authorization.v0.1",
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": "ACCEPT",
+        "authorization_state": "EXPIRED_AT_REPORT",
+        "execution_status": "EXECUTED",
+        "integrity_verdict": "VERIFIED",
+        "verification_level": "FULL_LIFECYCLE_JOINED"
+      },
+      "required_record_roles": [
+        "authorization_record",
+        "observation_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "EXPIRED_AT_REPORT",
+        "execution": "OBSERVED_EXECUTED",
+        "response_integrity": "VERIFIED",
+        "expected_additional_side_effects": 0
+      }
+    },
+    {
+      "case_id": "pythialabs_authorized_but_false",
+      "participants": {
+        "authorization": "pythialabs.authorization.v0.1",
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": "ALLOW",
+        "authorization_state": "ACTIVE",
+        "execution_status": "EXECUTED",
+        "integrity_verdict": "FAILED",
+        "verification_level": "FULL_LIFECYCLE_JOINED"
+      },
+      "required_record_roles": [
+        "authorization_record",
+        "observation_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "VALID",
+        "execution": "OBSERVED_EXECUTED",
+        "response_integrity": "FAILED",
+        "expected_additional_side_effects": 1
+      }
+    },
+    {
+      "case_id": "proofpath_consumed_replay_blocked_honestly",
+      "participants": {
+        "authorization": "proofpath.authorization.v0.1",
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": "BLOCK",
+        "authorization_state": "CONSUMED",
+        "execution_status": "NONE",
+        "integrity_verdict": "VERIFIED",
+        "verification_level": "FULL_LIFECYCLE_JOINED"
+      },
+      "required_record_roles": [
+        "authorization_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "CONSUMED",
+        "execution": "NOT_OBSERVED",
+        "response_integrity": "VERIFIED",
+        "expected_additional_side_effects": 0
+      }
+    },
+    {
+      "case_id": "ibex_ltp_count_drift_without_authority",
+      "participants": {
+        "authorization": null,
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": null,
+        "authorization_state": null,
+        "execution_status": "EXECUTED",
+        "integrity_verdict": "FAILED",
+        "verification_level": "OBSERVATION_JOINED"
+      },
+      "required_record_roles": [
+        "observation_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "NOT_EVALUATED",
+        "execution": "OBSERVED_EXECUTED",
+        "response_integrity": "FAILED",
+        "expected_additional_side_effects": 0
+      }
+    },
+    {
+      "case_id": "pythialabs_mixed_claims_partial",
+      "participants": {
+        "authorization": "pythialabs.authorization.v0.1",
+        "observation": "ibex.manifest-observation.v0.1",
+        "integrity": "ltp.lifecycle-integrity.v0.1"
+      },
+      "local_outcomes": {
+        "authorization_decision": "ALLOW",
+        "authorization_state": "ACTIVE",
+        "execution_status": "EXECUTED",
+        "integrity_verdict": "PARTIAL",
+        "verification_level": "FULL_LIFECYCLE_JOINED"
+      },
+      "required_record_roles": [
+        "authorization_record",
+        "observation_record",
+        "response_integrity_record"
+      ],
+      "expected": {
+        "authority": "VALID",
+        "execution": "OBSERVED_EXECUTED",
+        "response_integrity": "PARTIAL",
+        "expected_additional_side_effects": 1
+      }
+    }
+  ]
+}

--- a/tools/verify_trustworthy_transition_ecosystem.py
+++ b/tools/verify_trustworthy_transition_ecosystem.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""Verify the cross-repository trustworthy-transition compatibility pack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+PROFILE = "org.liminal.trustworthy-transition.ecosystem-compatibility.v0.1"
+CANONICAL_PROFILE = "org.liminal.trustworthy-transition.three-record.v0.1"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+AUTHORIZATION_ROLE = "AUTHORIZATION_PRODUCER"
+OBSERVATION_ROLE = "OBSERVATION_BINDER"
+INTEGRITY_ROLE = "CLAIM_VERIFIER"
+
+CANONICAL_RECORDS = {
+    "authorization_record",
+    "observation_record",
+    "response_integrity_record",
+}
+AUTHORITY_VALUES = {
+    "VALID",
+    "DENIED",
+    "PENDING",
+    "EXPIRED",
+    "EXPIRED_AT_REPORT",
+    "CONSUMED",
+    "REVALIDATION_REQUIRED",
+    "NOT_EVALUATED",
+}
+EXECUTION_VALUES = {
+    "OBSERVED_EXECUTED",
+    "OBSERVED_BLOCKED",
+    "OBSERVED_ERRORED",
+    "NOT_OBSERVED",
+}
+INTEGRITY_VALUES = {"VERIFIED", "FAILED", "PARTIAL", "NOT_EVALUATED"}
+VERIFICATION_LEVELS = {
+    "TEXT_HEURISTIC",
+    "OBSERVATION_JOINED",
+    "FULL_LIFECYCLE_JOINED",
+}
+
+
+class EcosystemVerificationError(ValueError):
+    """Raised when the ecosystem compatibility pack is inconsistent."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise EcosystemVerificationError(f"cannot read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise EcosystemVerificationError(
+            f"invalid JSON in {path}: {error.msg}"
+        ) from error
+    if not isinstance(value, dict):
+        raise EcosystemVerificationError("fixture root must be an object")
+    return value
+
+
+def require_text(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EcosystemVerificationError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def require_string_list(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise EcosystemVerificationError(f"{label} must be a string array")
+    if len(value) != len(set(value)):
+        raise EcosystemVerificationError(f"{label} must not contain duplicates")
+    return value
+
+
+def require_map(value: Any, *, label: str) -> dict[str, str]:
+    if not isinstance(value, dict) or not value:
+        raise EcosystemVerificationError(f"{label} must be a non-empty object")
+    if any(
+        not isinstance(key, str)
+        or not key
+        or not isinstance(mapped, str)
+        or not mapped
+        for key, mapped in value.items()
+    ):
+        raise EcosystemVerificationError(
+            f"{label} must map non-empty strings to non-empty strings"
+        )
+    return value
+
+
+def verify_artifact_path(value: Any, *, label: str) -> str:
+    path = require_text(value, label=label)
+    parsed = PurePosixPath(path)
+    if parsed.is_absolute() or ".." in parsed.parts or "." in parsed.parts:
+        raise EcosystemVerificationError(
+            f"{label} must be a normalized relative repository path"
+        )
+    return path
+
+
+def verify_implementation(
+    value: Any,
+    *,
+    index: int,
+) -> tuple[str, dict[str, Any]]:
+    label = f"implementations[{index}]"
+    if not isinstance(value, dict):
+        raise EcosystemVerificationError(f"{label} must be an object")
+
+    required = {
+        "implementation_id",
+        "repository",
+        "pull_request",
+        "head_sha",
+        "artifact_path",
+        "local_profile",
+        "roles",
+        "canonical_records",
+    }
+    optional = {
+        "decision_map",
+        "authority_state_map",
+        "execution_status_map",
+        "integrity_verdict_map",
+        "verification_level_map",
+    }
+    unknown = set(value) - required - optional
+    missing = required - set(value)
+    if missing or unknown:
+        raise EcosystemVerificationError(
+            f"{label} keys invalid: missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+
+    implementation_id = require_text(
+        value["implementation_id"], label=f"{label}.implementation_id"
+    )
+    repository = require_text(value["repository"], label=f"{label}.repository")
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise EcosystemVerificationError(f"{label}.repository is invalid")
+    pull_request = value["pull_request"]
+    if not isinstance(pull_request, int) or isinstance(pull_request, bool) or pull_request <= 0:
+        raise EcosystemVerificationError(
+            f"{label}.pull_request must be a positive integer"
+        )
+    head_sha = require_text(value["head_sha"], label=f"{label}.head_sha")
+    if not SHA_RE.fullmatch(head_sha):
+        raise EcosystemVerificationError(
+            f"{label}.head_sha must be a lowercase 40-character commit SHA"
+        )
+    verify_artifact_path(value["artifact_path"], label=f"{label}.artifact_path")
+    require_text(value["local_profile"], label=f"{label}.local_profile")
+
+    roles = set(require_string_list(value["roles"], label=f"{label}.roles"))
+    records = set(
+        require_string_list(
+            value["canonical_records"],
+            label=f"{label}.canonical_records",
+        )
+    )
+    if not records <= CANONICAL_RECORDS:
+        raise EcosystemVerificationError(
+            f"{label} declares unknown canonical records: "
+            f"{sorted(records - CANONICAL_RECORDS)}"
+        )
+
+    if AUTHORIZATION_ROLE in roles:
+        decision_map = require_map(
+            value.get("decision_map"), label=f"{label}.decision_map"
+        )
+        state_map = require_map(
+            value.get("authority_state_map"),
+            label=f"{label}.authority_state_map",
+        )
+        if not set(decision_map.values()) <= {"ALLOW", "DENY", "DEFER"}:
+            raise EcosystemVerificationError(
+                f"{label}.decision_map has non-canonical values"
+            )
+        if not set(state_map.values()) <= AUTHORITY_VALUES - {"NOT_EVALUATED"}:
+            raise EcosystemVerificationError(
+                f"{label}.authority_state_map has non-canonical values"
+            )
+        if "authorization_record" not in records:
+            raise EcosystemVerificationError(
+                f"{label} authority producer must export authorization_record"
+            )
+
+    if OBSERVATION_ROLE in roles:
+        execution_map = require_map(
+            value.get("execution_status_map"),
+            label=f"{label}.execution_status_map",
+        )
+        if not set(execution_map.values()) <= EXECUTION_VALUES:
+            raise EcosystemVerificationError(
+                f"{label}.execution_status_map has non-canonical values"
+            )
+        if "observation_record" not in records:
+            raise EcosystemVerificationError(
+                f"{label} observation binder must export observation_record"
+            )
+
+    if INTEGRITY_ROLE in roles:
+        verdict_map = require_map(
+            value.get("integrity_verdict_map"),
+            label=f"{label}.integrity_verdict_map",
+        )
+        level_map = require_map(
+            value.get("verification_level_map"),
+            label=f"{label}.verification_level_map",
+        )
+        if not set(verdict_map.values()) <= INTEGRITY_VALUES:
+            raise EcosystemVerificationError(
+                f"{label}.integrity_verdict_map has non-canonical values"
+            )
+        if set(level_map.values()) != VERIFICATION_LEVELS:
+            raise EcosystemVerificationError(
+                f"{label}.verification_level_map must expose all evidence levels"
+            )
+        if "response_integrity_record" not in records:
+            raise EcosystemVerificationError(
+                f"{label} claim verifier must export response_integrity_record"
+            )
+
+    normalized = dict(value)
+    normalized["roles"] = roles
+    normalized["canonical_records"] = records
+    normalized["source_url"] = (
+        f"https://github.com/{repository}/pull/{pull_request}"
+    )
+    return implementation_id, normalized
+
+
+def derive_authority(
+    authorization: dict[str, Any] | None,
+    outcomes: dict[str, Any],
+    *,
+    case_id: str,
+) -> str:
+    if authorization is None:
+        if outcomes.get("authorization_decision") is not None or outcomes.get(
+            "authorization_state"
+        ) is not None:
+            raise EcosystemVerificationError(
+                f"{case_id} has authority outcomes without an authority producer"
+            )
+        return "NOT_EVALUATED"
+
+    decision = outcomes.get("authorization_decision")
+    state = outcomes.get("authorization_state")
+    if not isinstance(decision, str) or not isinstance(state, str):
+        raise EcosystemVerificationError(
+            f"{case_id} requires string authorization decision and state"
+        )
+
+    decision_map = authorization["decision_map"]
+    state_map = authorization["authority_state_map"]
+    if decision not in decision_map:
+        raise EcosystemVerificationError(
+            f"{case_id} unknown local authorization decision: {decision}"
+        )
+    if state not in state_map:
+        raise EcosystemVerificationError(
+            f"{case_id} unknown local authorization state: {state}"
+        )
+
+    normalized_state = state_map[state]
+    if normalized_state != "VALID":
+        return normalized_state
+
+    normalized_decision = decision_map[decision]
+    if normalized_decision == "ALLOW":
+        return "VALID"
+    if normalized_decision == "DENY":
+        return "DENIED"
+    return "PENDING"
+
+
+def verify_case(
+    value: Any,
+    *,
+    index: int,
+    implementations: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    label = f"cases[{index}]"
+    if not isinstance(value, dict):
+        raise EcosystemVerificationError(f"{label} must be an object")
+    required = {
+        "case_id",
+        "participants",
+        "local_outcomes",
+        "required_record_roles",
+        "expected",
+    }
+    if set(value) != required:
+        raise EcosystemVerificationError(
+            f"{label} must contain exactly {sorted(required)}"
+        )
+
+    case_id = require_text(value["case_id"], label=f"{label}.case_id")
+    participants = value["participants"]
+    outcomes = value["local_outcomes"]
+    expected = value["expected"]
+    if not all(isinstance(item, dict) for item in (participants, outcomes, expected)):
+        raise EcosystemVerificationError(
+            f"{case_id} participants, local_outcomes, and expected must be objects"
+        )
+    if set(participants) != {"authorization", "observation", "integrity"}:
+        raise EcosystemVerificationError(f"{case_id} participant roles are invalid")
+
+    def implementation_for(
+        participant_role: str,
+        required_role: str,
+        *,
+        nullable: bool = False,
+    ) -> dict[str, Any] | None:
+        implementation_id = participants[participant_role]
+        if implementation_id is None and nullable:
+            return None
+        if not isinstance(implementation_id, str) or implementation_id not in implementations:
+            raise EcosystemVerificationError(
+                f"{case_id} references unknown {participant_role} implementation"
+            )
+        implementation = implementations[implementation_id]
+        if required_role not in implementation["roles"]:
+            raise EcosystemVerificationError(
+                f"{case_id} {participant_role} implementation lacks {required_role}"
+            )
+        return implementation
+
+    authorization = implementation_for(
+        "authorization", AUTHORIZATION_ROLE, nullable=True
+    )
+    observation = implementation_for("observation", OBSERVATION_ROLE)
+    integrity = implementation_for("integrity", INTEGRITY_ROLE)
+    assert observation is not None and integrity is not None
+
+    authority = derive_authority(
+        authorization,
+        outcomes,
+        case_id=case_id,
+    )
+
+    execution_status = outcomes.get("execution_status")
+    if not isinstance(execution_status, str):
+        raise EcosystemVerificationError(
+            f"{case_id}.execution_status must be a string"
+        )
+    execution_map = observation["execution_status_map"]
+    if execution_status not in execution_map:
+        raise EcosystemVerificationError(
+            f"{case_id} unknown local execution status: {execution_status}"
+        )
+    execution = execution_map[execution_status]
+
+    integrity_verdict = outcomes.get("integrity_verdict")
+    if not isinstance(integrity_verdict, str):
+        raise EcosystemVerificationError(
+            f"{case_id}.integrity_verdict must be a string"
+        )
+    integrity_map = integrity["integrity_verdict_map"]
+    if integrity_verdict not in integrity_map:
+        raise EcosystemVerificationError(
+            f"{case_id} unknown local integrity verdict: {integrity_verdict}"
+        )
+    response_integrity = integrity_map[integrity_verdict]
+
+    level = outcomes.get("verification_level")
+    if not isinstance(level, str) or level not in integrity["verification_level_map"]:
+        raise EcosystemVerificationError(
+            f"{case_id} unknown verification level: {level}"
+        )
+    normalized_level = integrity["verification_level_map"][level]
+    if normalized_level == "FULL_LIFECYCLE_JOINED" and authorization is None:
+        raise EcosystemVerificationError(
+            f"{case_id} full lifecycle verification requires authorization"
+        )
+    if normalized_level in {"OBSERVATION_JOINED", "FULL_LIFECYCLE_JOINED"} and execution == "NOT_OBSERVED":
+        if response_integrity == "VERIFIED":
+            raise EcosystemVerificationError(
+                f"{case_id} cannot verify observation-backed claims without observation"
+            )
+
+    record_roles = set(
+        require_string_list(
+            value["required_record_roles"],
+            label=f"{case_id}.required_record_roles",
+        )
+    )
+    if not record_roles <= CANONICAL_RECORDS:
+        raise EcosystemVerificationError(
+            f"{case_id} requires unknown canonical record roles"
+        )
+    if authorization is not None and "authorization_record" not in record_roles:
+        raise EcosystemVerificationError(
+            f"{case_id} omits required authorization_record"
+        )
+    if execution != "NOT_OBSERVED" and "observation_record" not in record_roles:
+        raise EcosystemVerificationError(
+            f"{case_id} omits required observation_record"
+        )
+    if "response_integrity_record" not in record_roles:
+        raise EcosystemVerificationError(
+            f"{case_id} omits required response_integrity_record"
+        )
+
+    expected_keys = {
+        "authority",
+        "execution",
+        "response_integrity",
+        "expected_additional_side_effects",
+    }
+    if set(expected) != expected_keys:
+        raise EcosystemVerificationError(
+            f"{case_id}.expected must contain exactly {sorted(expected_keys)}"
+        )
+    derived = {
+        "authority": authority,
+        "execution": execution,
+        "response_integrity": response_integrity,
+    }
+    for key, actual in derived.items():
+        if expected.get(key) != actual:
+            raise EcosystemVerificationError(
+                f"{case_id} {key} mismatch: expected {expected.get(key)}, "
+                f"derived {actual}"
+            )
+
+    expected_side_effects = 1 if (
+        authority == "VALID" and execution == "OBSERVED_EXECUTED"
+    ) else 0
+    side_effects = expected.get("expected_additional_side_effects")
+    if side_effects != expected_side_effects:
+        raise EcosystemVerificationError(
+            f"{case_id} expected_additional_side_effects mismatch: "
+            f"expected {side_effects}, derived {expected_side_effects}"
+        )
+
+    return {
+        "case_id": case_id,
+        "participants": dict(participants),
+        "verification_level": normalized_level,
+        "dimensions": derived,
+        "required_record_roles": sorted(record_roles),
+        "expected_additional_side_effects": expected_side_effects,
+    }
+
+
+def verify_join_contract(value: Any) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        raise EcosystemVerificationError("join_contract must be an object")
+    required = {
+        "authorization_to_observation",
+        "observation_to_integrity",
+        "independent_dimensions",
+        "claim_verdicts",
+    }
+    if set(value) != required:
+        raise EcosystemVerificationError(
+            f"join_contract must contain exactly {sorted(required)}"
+        )
+    normalized = {
+        key: require_string_list(items, label=f"join_contract.{key}")
+        for key, items in value.items()
+    }
+    auth_join = set(normalized["authorization_to_observation"])
+    if not {
+        "transition_id",
+        "subject_id",
+        "authorization_ref",
+        "action_identity_digest",
+        "binding_digest",
+    } <= auth_join:
+        raise EcosystemVerificationError(
+            "authorization_to_observation omits required portable join keys"
+        )
+    integrity_join = set(normalized["observation_to_integrity"])
+    if not {
+        "transition_id",
+        "subject_id",
+        "authorization_ref",
+        "observation_refs",
+    } <= integrity_join:
+        raise EcosystemVerificationError(
+            "observation_to_integrity omits required portable join keys"
+        )
+    if normalized["independent_dimensions"] != [
+        "authority",
+        "execution",
+        "response_integrity",
+    ]:
+        raise EcosystemVerificationError(
+            "independent_dimensions order or values changed"
+        )
+    if set(normalized["claim_verdicts"]) != {
+        "SUPPORTED",
+        "CONTRADICTED",
+        "UNVERIFIABLE",
+        "OUT_OF_SCOPE",
+    }:
+        raise EcosystemVerificationError("claim verdict vocabulary mismatch")
+    return normalized
+
+
+def verify_fixture(path: Path) -> dict[str, Any]:
+    fixture = load_json(path)
+    required = {
+        "schema_version",
+        "profile",
+        "canonical_profile",
+        "implementations",
+        "join_contract",
+        "cases",
+    }
+    if set(fixture) != required:
+        raise EcosystemVerificationError(
+            f"fixture must contain exactly {sorted(required)}"
+        )
+    if fixture["schema_version"] != 1:
+        raise EcosystemVerificationError("unsupported schema_version")
+    if fixture["profile"] != PROFILE:
+        raise EcosystemVerificationError("ecosystem profile mismatch")
+    if fixture["canonical_profile"] != CANONICAL_PROFILE:
+        raise EcosystemVerificationError("canonical profile mismatch")
+
+    raw_implementations = fixture["implementations"]
+    if not isinstance(raw_implementations, list) or not raw_implementations:
+        raise EcosystemVerificationError("implementations must be a non-empty array")
+    implementations: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(raw_implementations):
+        implementation_id, normalized = verify_implementation(item, index=index)
+        if implementation_id in implementations:
+            raise EcosystemVerificationError(
+                f"duplicate implementation_id: {implementation_id}"
+            )
+        implementations[implementation_id] = normalized
+
+    all_roles = set().union(
+        *(implementation["roles"] for implementation in implementations.values())
+    )
+    for required_role in (AUTHORIZATION_ROLE, OBSERVATION_ROLE, INTEGRITY_ROLE):
+        if required_role not in all_roles:
+            raise EcosystemVerificationError(
+                f"ecosystem pack has no implementation for {required_role}"
+            )
+
+    join_contract = verify_join_contract(fixture["join_contract"])
+
+    raw_cases = fixture["cases"]
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise EcosystemVerificationError("cases must be a non-empty array")
+    case_reports: list[dict[str, Any]] = []
+    seen_case_ids: set[str] = set()
+    for index, case in enumerate(raw_cases):
+        report = verify_case(
+            case,
+            index=index,
+            implementations=implementations,
+        )
+        case_id = report["case_id"]
+        if case_id in seen_case_ids:
+            raise EcosystemVerificationError(f"duplicate case_id: {case_id}")
+        seen_case_ids.add(case_id)
+        case_reports.append(report)
+
+    dimensions = Counter(
+        (
+            report["dimensions"]["authority"],
+            report["dimensions"]["execution"],
+            report["dimensions"]["response_integrity"],
+        )
+        for report in case_reports
+    )
+    if len(dimensions) < 5:
+        raise EcosystemVerificationError(
+            "fixture does not exercise enough independent verdict combinations"
+        )
+
+    return {
+        "schema_version": 1,
+        "status": "VERIFIED",
+        "profile": PROFILE,
+        "canonical_profile": CANONICAL_PROFILE,
+        "implementations": [
+            {
+                "implementation_id": implementation_id,
+                "repository": implementation["repository"],
+                "pull_request": implementation["pull_request"],
+                "head_sha": implementation["head_sha"],
+                "source_url": implementation["source_url"],
+                "roles": sorted(implementation["roles"]),
+                "canonical_records": sorted(
+                    implementation["canonical_records"]
+                ),
+            }
+            for implementation_id, implementation in sorted(
+                implementations.items()
+            )
+        ],
+        "join_contract": join_contract,
+        "cases": case_reports,
+        "summary": {
+            "implementation_count": len(implementations),
+            "case_count": len(case_reports),
+            "independent_dimension_combinations": len(dimensions),
+        },
+        "claim_boundary": (
+            "This offline pack verifies pinned implementation metadata, local-to-"
+            "canonical vocabulary mappings, record-role coverage, and independent "
+            "verdict derivation. It does not fetch remote code, attest current PR "
+            "heads, or replace each repository's own tests and review gates."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "fixture",
+        nargs="?",
+        type=Path,
+        default=Path(
+            "fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json"
+        ),
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        receipt = verify_fixture(args.fixture)
+        rendered = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        else:
+            print(rendered, end="")
+        return 0
+    except EcosystemVerificationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the second layer of Liminal #108: a deterministic ecosystem compatibility pack for concrete three-record implementations.

The canonical profile is already merged in #109. This PR pins the current implementation adapters and verifies that their local vocabularies normalize into the same independent authority, execution, and response-integrity dimensions.

## Pinned implementations

- ProofPath PR #167 at `e8bd2641752282c7eea2cfe4650246a77df2bfbc`
- PythiaLabs PR #205 at `dbe5668164f7650ae0ce7f9fd2f2d0f14d92ea71`
- ibex-agent-verification PR #58 at `4e73022c01c3bd0f458eab2fad0d0b351b5dfb58`
- LTP PR #481 at `b1fcf43977a2de5cd21b84887d6dcdc1d451acd1`

Each entry declares its repository, PR, exact head SHA, implementation artifact, local profile, owned boundary, exported canonical records, and local-to-canonical vocabulary maps.

## Added

- `fixtures/trustworthy-transition-ecosystem-compatibility-v0.1.json`
- `tools/verify_trustworthy_transition_ecosystem.py`
- `docs/interop/TRUSTWORTHY_TRANSITION_ECOSYSTEM_COMPATIBILITY_V0_1.md`
- `.github/workflows/trustworthy-transition-conformance.yml`

## Verification

The offline verifier checks:

- pinned implementation metadata and normalized repository paths;
- role ownership and canonical record coverage;
- provider-local decision/state mappings;
- execution and integrity mappings;
- required authorization → observation join keys;
- required observation → response-integrity join keys;
- independent dimension derivation for every case;
- zero additional side effects outside `VALID + OBSERVED_EXECUTED`;
- full-lifecycle verification cannot exist without authority;
- observation-backed claims cannot be marked verified without observation evidence.

## Compatibility cases

1. ProofPath + ibex + LTP fully supported;
2. PythiaLabs blocked action claimed as executed;
3. ProofPath expired-at-report authority with honest historical reporting;
4. PythiaLabs authorized execution with a false response;
5. ProofPath consumed replay with an observed runtime block and honest response;
6. ibex + LTP count drift without imported authority;
7. PythiaLabs mixed supported/unverifiable claims.

The pack explicitly preserves combinations such as:

```text
VALID + OBSERVED_EXECUTED + FAILED
EXPIRED_AT_REPORT + OBSERVED_EXECUTED + VERIFIED
CONSUMED + OBSERVED_BLOCKED + VERIFIED
NOT_EVALUATED + OBSERVED_EXECUTED + FAILED
```

## CI

The new workflow runs both:

```bash
python3 tools/verify_trustworthy_transition_vector.py
python3 tools/verify_trustworthy_transition_ecosystem.py
```

The `Trustworthy Transition Conformance` workflow is green and uploads the deterministic compatibility receipt as an artifact.

## Review gate

- CodeRabbit: passed with no inline findings.
- Codex review: requested, but blocked because the connected Codex account reached its code-review usage limit.
- PR remains draft and must not be merged until the mandatory Codex review is completed and the final rerun is green.

## Boundary

This pack is deliberately offline. It verifies checked-in pins and mappings, but does not fetch mutable branches or replace repository-local CI, CodeRabbit, or the mandatory Codex review gate.

Relates to #108.