### PR TITLE
feat: add trustworthy-transition release train v0.1

### DIFF
--- a/.github/workflows/trustworthy-transition-release-train.yml
+++ b/.github/workflows/trustworthy-transition-release-train.yml
@@ -1,0 +1,48 @@
+name: Trustworthy Transition Release Train
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - "releases/trustworthy-transition-*"
+      - "tools/verify_trustworthy_transition_release_train.py"
+      - "docs/interop/TRUSTWORTHY_TRANSITION_RELEASE_TRAIN_*"
+      - ".github/workflows/trustworthy-transition-release-train.yml"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  statuses: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify release manifest offline
+        run: |
+          mkdir -p artifacts
+          python3 tools/verify_trustworthy_transition_release_train.py \
+            --output artifacts/trustworthy-transition-release-train-offline.json
+
+      - name: Verify pinned GitHub state live
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 tools/verify_trustworthy_transition_release_train.py \
+            --live \
+            --output artifacts/trustworthy-transition-release-train-live.json
+
+      - name: Upload release-train receipts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trustworthy-transition-release-train-receipts
+          path: artifacts/trustworthy-transition-release-train-*.json
+          if-no-files-found: error

--- a/.github/workflows/trustworthy-transition-release-train.yml
+++ b/.github/workflows/trustworthy-transition-release-train.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -35,6 +37,7 @@ jobs:
       - name: Verify pinned GitHub state live
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TRUSTWORTHY_TRAIN_ALLOWED_GITHUB_API_HOSTS: api.github.com
         run: |
           python3 tools/verify_trustworthy_transition_release_train.py \
             --live \

--- a/docs/interop/TRUSTWORTHY_TRANSITION_RELEASE_TRAIN_V0_1.md
+++ b/docs/interop/TRUSTWORTHY_TRANSITION_RELEASE_TRAIN_V0_1.md
@@ -106,6 +106,12 @@ Every stage pins:
 `expected_base_sha` may change after retargeting the immediate successor to the
 new `main` head.
 
+Offline validation also binds base SHAs:
+
+- stage 1 base SHA must equal `target.initial_head`;
+- a merged successor's base SHA must equal its predecessor's merge commit;
+- an open successor of a merged stage must target the current `main` head.
+
 ## Live verification
 
 Run offline schema and invariant checks:
@@ -119,6 +125,7 @@ Run live GitHub verification:
 
 ```bash
 GITHUB_TOKEN=... \
+TRUSTWORTHY_TRAIN_ALLOWED_GITHUB_API_HOSTS=api.github.com \
 python3 tools/verify_trustworthy_transition_release_train.py \
   --live \
   --output artifacts/release-train-live-receipt.json
@@ -138,11 +145,16 @@ The live mode checks:
 
 The normalized live state is hashed into `live_state_digest`.
 
+Before attaching `GITHUB_TOKEN`, the client requires HTTPS and an allowlisted API
+host. The default allowlist contains only `api.github.com`. GitHub Enterprise
+installations must explicitly supply their API hostname through
+`TRUSTWORTHY_TRAIN_ALLOWED_GITHUB_API_HOSTS`.
+
 ## Merge procedure
 
 ### Before merging #110
 
-- complete mandatory Codex review;
+- complete mandatory CodeRabbit and Codex review;
 - keep all three stage heads unchanged;
 - run offline and live release-train verification;
 - merge #110 using **Create a merge commit** only.
@@ -161,10 +173,34 @@ The normalized live state is hashed into `live_state_digest`.
 
 Repeat the same sequence for #113 and then #116.
 
+## Review state and next action
+
+The manifest records both review gates:
+
+```text
+coderabbit_status = PENDING | PASSED
+codex_status      = PENDING | PASSED
+```
+
+`next_action` is derived from those review states and the merged-stage count:
+
+```text
+COMPLETE_CODERABBIT_REVIEW
+COMPLETE_CODEX_REVIEW
+MERGE_PR_110_WITH_MERGE_COMMIT
+RETARGET_PR_113_TO_MAIN_RERUN_AND_REPIN
+RETARGET_PR_116_TO_MAIN_RERUN_AND_REPIN
+ISSUE_FINAL_MAIN_MANIFEST
+```
+
+A stale human-readable instruction therefore fails validation instead of being
+silently accepted.
+
 ## Blocker derivation
 
-The verifier derives blockers from train state:
+The verifier derives blockers from train and review state:
 
+- `CODERABBIT_REVIEW_PENDING` while CodeRabbit is not `PASSED`;
 - `CODEX_REVIEW_PENDING` while Codex is not `PASSED`;
 - `STACK_NOT_MERGED` until all three stages are merged;
 - `FINAL_MAIN_MANIFEST_NOT_ISSUED` for every release candidate.
@@ -200,7 +236,9 @@ on its ancestry.
 ## Security and trust boundary
 
 The workflow uses read-only permissions for contents, pull requests, actions,
-and commit statuses. It does not merge PRs or modify branches.
+and commit statuses. Checkout credential persistence is disabled. The token is
+injected only into the live step after API URL validation. The workflow does not
+merge PRs or modify branches.
 
 The release-train verifier does not replace:
 

--- a/docs/interop/TRUSTWORTHY_TRANSITION_RELEASE_TRAIN_V0_1.md
+++ b/docs/interop/TRUSTWORTHY_TRANSITION_RELEASE_TRAIN_V0_1.md
@@ -1,0 +1,215 @@
+# Trustworthy Transition Release Train v0.1
+
+**Status:** Draft release-candidate protocol  
+**Tracking issue:** [Liminal #117](https://github.com/safal207/Liminal/issues/117)
+
+## Purpose
+
+This profile controls the stacked merge sequence for:
+
+```text
+PR #110  ecosystem compatibility v0.1
+    ↓
+PR #113  full lifecycle compatibility v0.2
+    ↓
+PR #116  durability assurance compatibility v0.3
+```
+
+It prevents a valid stack from silently becoming invalid because of:
+
+- head SHA drift;
+- base branch drift;
+- broken predecessor ancestry;
+- stale workflow or receipt pins;
+- expired artifacts;
+- a failed required status;
+- squash or rebase merge of a stacked predecessor;
+- retargeting a successor while changing its head.
+
+## Frozen ancestry
+
+The initial candidate is frozen as:
+
+```text
+main@426bf5c41a6215b0fef1e9ca59df00a880491c14
+  → #110@2ac45920526526bbe42fcbcff7d7fca80cd667eb  (+6)
+  → #113@b50ef4d90a76fbd5b5d2e835f85e348081f4110f  (+5)
+  → #116@c2864dd9f57e962064f24b6cc6368f647ebaaea4  (+7)
+```
+
+The verifier checks each edge against GitHub's compare API. The child must be a
+strict descendant, have `behind_by = 0`, preserve the exact merge base, and
+contain the pinned delta commit count.
+
+## Why merge commits are mandatory
+
+A GitHub merge commit preserves both parents:
+
+```text
+parent 1 = exact target branch head
+parent 2 = exact stacked PR head
+```
+
+This lets the next branch keep its existing head and ancestry.
+
+Squash merge and rebase merge rewrite commit identity. They can make the next PR
+show predecessor changes again, invalidate pinned head SHAs, and detach existing
+receipts from the release candidate. Therefore the manifest requires:
+
+```text
+required_method = merge_commit
+forbidden_methods = squash, rebase
+```
+
+For a merged stage, the live verifier fetches the merge commit and requires
+exactly two parents equal to the pinned base SHA and PR head SHA.
+
+## Candidate phases
+
+The same manifest schema remains usable throughout the train:
+
+```text
+PRE_MERGE_FROZEN
+STAGE_1_MERGED
+STAGE_2_MERGED
+STACK_MERGED_PENDING_FINAL
+```
+
+Merged stages must form a prefix. An open stage may never appear before a merged
+stage.
+
+The current `target.expected_head` must be:
+
+- `target.initial_head` before any merge;
+- the latest merged stage's merge commit afterward.
+
+This intentionally fails closed if an unrelated commit lands on `main`. The
+candidate must then be refreshed and revalidated instead of silently absorbing
+new target state.
+
+## Per-stage pins
+
+Every stage pins:
+
+- PR number;
+- train state;
+- head branch and head SHA;
+- expected live base branch and SHA;
+- immutable ancestry parent SHA;
+- predecessor PR;
+- delta commit count;
+- exact successful workflow run IDs;
+- required commit statuses;
+- receipt workflow run, artifact ID, name, and SHA-256 digest.
+
+`ancestry_parent_sha` never changes while the PR head remains unchanged.
+`expected_base_sha` may change after retargeting the immediate successor to the
+new `main` head.
+
+## Live verification
+
+Run offline schema and invariant checks:
+
+```bash
+python3 tools/verify_trustworthy_transition_release_train.py \
+  --output artifacts/release-train-offline-receipt.json
+```
+
+Run live GitHub verification:
+
+```bash
+GITHUB_TOKEN=... \
+python3 tools/verify_trustworthy_transition_release_train.py \
+  --live \
+  --output artifacts/release-train-live-receipt.json
+```
+
+The live mode checks:
+
+1. current `main` head;
+2. PR open/merged state;
+3. exact head branch and SHA;
+4. exact live base for open stages;
+5. two-parent merge commit for merged stages;
+6. predecessor ancestry and delta count;
+7. pinned workflow run name, event, head, and successful conclusion;
+8. receipt artifact name, digest, expiry state, run binding, and head binding;
+9. latest required commit status, currently `CodeRabbit`.
+
+The normalized live state is hashed into `live_state_digest`.
+
+## Merge procedure
+
+### Before merging #110
+
+- complete mandatory Codex review;
+- keep all three stage heads unchanged;
+- run offline and live release-train verification;
+- merge #110 using **Create a merge commit** only.
+
+### After merging #110
+
+1. record #110's merge commit SHA;
+2. set stage 1 to `MERGED` and add `merge_commit_sha`;
+3. update `target.expected_head` to that merge commit;
+4. retarget #113 from `feat/ecosystem-pack-v0.1` to `main`;
+5. do not rebase or modify #113 head;
+6. update #113's expected base SHA to the new `main` head;
+7. rerun all required workflows;
+8. replace #113 workflow and receipt pins with the new successful runs;
+9. set `candidate_state = STAGE_1_MERGED` and rerun live verification.
+
+Repeat the same sequence for #113 and then #116.
+
+## Blocker derivation
+
+The verifier derives blockers from train state:
+
+- `CODEX_REVIEW_PENDING` while Codex is not `PASSED`;
+- `STACK_NOT_MERGED` until all three stages are merged;
+- `FINAL_MAIN_MANIFEST_NOT_ISSUED` for every release candidate.
+
+A release-candidate manifest always has:
+
+```text
+release_ready = false
+```
+
+After all stages merge, generate a separate final manifest from `main`. Do not
+turn the candidate into a final release merely by changing a boolean.
+
+## Invalidation
+
+The candidate is invalid when any of these occurs:
+
+```text
+TARGET_HEAD_CHANGED
+PINNED_PR_HEAD_CHANGED
+PINNED_PR_BASE_CHANGED
+ANCESTRY_CHANGED
+WORKFLOW_RUN_CHANGED_OR_FAILED
+RECEIPT_ARTIFACT_CHANGED_OR_EXPIRED
+REQUIRED_COMMIT_STATUS_NOT_SUCCESSFUL
+SUCCESSOR_HEAD_CHANGED_AFTER_RETARGET
+NON_MERGE_COMMIT_STRATEGY_USED
+```
+
+Head drift invalidates that stage's receipt and every downstream pin that relies
+on its ancestry.
+
+## Security and trust boundary
+
+The workflow uses read-only permissions for contents, pull requests, actions,
+and commit statuses. It does not merge PRs or modify branches.
+
+The release-train verifier does not replace:
+
+- semantic conformance verification;
+- CodeRabbit;
+- mandatory Codex review;
+- branch protection;
+- repository-local CI;
+- human release approval.
+
+It proves that the release metadata still describes the live repository state
+it claims to describe.

--- a/releases/trustworthy-transition-release-candidate-v0.3.json
+++ b/releases/trustworthy-transition-release-candidate-v0.3.json
@@ -21,6 +21,7 @@
   },
   "review_policy": {
     "coderabbit_required": true,
+    "coderabbit_status": "PASSED",
     "codex_required": true,
     "codex_status": "PENDING"
   },
@@ -100,7 +101,7 @@
       }
     }
   ],
-  "next_action": "COMPLETE_CODEX_REVIEW_THEN_MERGE_PR_110_WITH_MERGE_COMMIT",
+  "next_action": "COMPLETE_CODEX_REVIEW",
   "release_blockers": [
     "CODEX_REVIEW_PENDING",
     "STACK_NOT_MERGED",

--- a/releases/trustworthy-transition-release-candidate-v0.3.json
+++ b/releases/trustworthy-transition-release-candidate-v0.3.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "profile": "org.liminal.trustworthy-transition.release-train.v0.1",
+  "candidate_id": "trustworthy-transition-v0.3-rc1",
+  "candidate_state": "PRE_MERGE_FROZEN",
+  "release_ready": false,
+  "repository": "safal207/Liminal",
+  "target": {
+    "branch": "main",
+    "expected_head": "426bf5c41a6215b0fef1e9ca59df00a880491c14",
+    "drift_policy": "REFRESH_REQUIRED"
+  },
+  "merge_policy": {
+    "required_method": "merge_commit",
+    "forbidden_methods": ["squash", "rebase"],
+    "preserve_successor_head": true,
+    "retarget_immediate_successor_only": true,
+    "rerun_after_retarget": true,
+    "final_main_manifest_required": true
+  },
+  "review_policy": {
+    "coderabbit_required": true,
+    "codex_required": true,
+    "codex_status": "PENDING"
+  },
+  "stages": [
+    {
+      "order": 1,
+      "layer": "ecosystem-compatibility-v0.1",
+      "pull_request": 110,
+      "train_state": "OPEN_STACKED",
+      "head_branch": "feat/ecosystem-pack-v0.1",
+      "head_sha": "2ac45920526526bbe42fcbcff7d7fca80cd667eb",
+      "expected_base_branch": "main",
+      "expected_base_sha": "426bf5c41a6215b0fef1e9ca59df00a880491c14",
+      "ancestry_parent_sha": "426bf5c41a6215b0fef1e9ca59df00a880491c14",
+      "predecessor_pull_request": null,
+      "delta_commits": 6,
+      "workflow_runs": [
+        {"name": "Trustworthy Transition Conformance", "run_id": 28337987520},
+        {"name": "Python Integration (WS)", "run_id": 28337987526},
+        {"name": "Artillery WebSocket Smoke", "run_id": 28337987511},
+        {"name": "Python CI", "run_id": 28337987518}
+      ],
+      "required_commit_statuses": ["CodeRabbit"],
+      "receipt": {
+        "workflow_run_id": 28337987520,
+        "artifact_id": 7939181967,
+        "artifact_name": "trustworthy-transition-ecosystem-receipt",
+        "artifact_digest": "sha256:7a18bdd9be4e04ce6b3b24437646ee947d71425c538cb671e1cd98ae382c7384"
+      }
+    },
+    {
+      "order": 2,
+      "layer": "full-lifecycle-compatibility-v0.2",
+      "pull_request": 113,
+      "train_state": "OPEN_STACKED",
+      "head_branch": "feat/full-lifecycle-ecosystem-v0.2",
+      "head_sha": "b50ef4d90a76fbd5b5d2e835f85e348081f4110f",
+      "expected_base_branch": "feat/ecosystem-pack-v0.1",
+      "expected_base_sha": "2ac45920526526bbe42fcbcff7d7fca80cd667eb",
+      "ancestry_parent_sha": "2ac45920526526bbe42fcbcff7d7fca80cd667eb",
+      "predecessor_pull_request": 110,
+      "delta_commits": 5,
+      "workflow_runs": [
+        {"name": "Trustworthy Transition Conformance", "run_id": 28348477486},
+        {"name": "Python Integration (WS)", "run_id": 28348477490}
+      ],
+      "required_commit_statuses": ["CodeRabbit"],
+      "receipt": {
+        "workflow_run_id": 28348477486,
+        "artifact_id": 7942564321,
+        "artifact_name": "trustworthy-transition-conformance-receipts",
+        "artifact_digest": "sha256:b6af0ea449cb0426dc94cac9e25f1a4e2a9d76ae257109316a41886779c20583"
+      }
+    },
+    {
+      "order": 3,
+      "layer": "durability-assurance-compatibility-v0.3",
+      "pull_request": 116,
+      "train_state": "OPEN_STACKED",
+      "head_branch": "feat/durability-assurance-v0.3",
+      "head_sha": "c2864dd9f57e962064f24b6cc6368f647ebaaea4",
+      "expected_base_branch": "feat/full-lifecycle-ecosystem-v0.2",
+      "expected_base_sha": "b50ef4d90a76fbd5b5d2e835f85e348081f4110f",
+      "ancestry_parent_sha": "b50ef4d90a76fbd5b5d2e835f85e348081f4110f",
+      "predecessor_pull_request": 113,
+      "delta_commits": 7,
+      "workflow_runs": [
+        {"name": "Trustworthy Transition Conformance", "run_id": 28357797284},
+        {"name": "Python Integration (WS)", "run_id": 28357797345}
+      ],
+      "required_commit_statuses": ["CodeRabbit"],
+      "receipt": {
+        "workflow_run_id": 28357797284,
+        "artifact_id": 7946021026,
+        "artifact_name": "trustworthy-transition-conformance-receipts",
+        "artifact_digest": "sha256:eacf4140fa5b5fc143afebf275460dc49c9f6fd1149aab3fa2b4a616d6ff79ab"
+      }
+    }
+  ],
+  "next_action": "COMPLETE_CODEX_REVIEW_THEN_MERGE_PR_110_WITH_MERGE_COMMIT",
+  "release_blockers": [
+    "CODEX_REVIEW_PENDING",
+    "STACK_NOT_MERGED",
+    "FINAL_MAIN_MANIFEST_NOT_ISSUED"
+  ],
+  "invalidation_rules": [
+    "TARGET_HEAD_CHANGED",
+    "PINNED_PR_HEAD_CHANGED",
+    "PINNED_PR_BASE_CHANGED",
+    "ANCESTRY_CHANGED",
+    "WORKFLOW_RUN_CHANGED_OR_FAILED",
+    "RECEIPT_ARTIFACT_CHANGED_OR_EXPIRED",
+    "REQUIRED_COMMIT_STATUS_NOT_SUCCESSFUL",
+    "SUCCESSOR_HEAD_CHANGED_AFTER_RETARGET",
+    "NON_MERGE_COMMIT_STRATEGY_USED"
+  ],
+  "claim_boundary": {
+    "pre_merge_candidate_only": true,
+    "semantic_conformance_replaced": false,
+    "code_review_replaced": false,
+    "branch_protection_replaced": false,
+    "human_merge_decision_replaced": false
+  }
+}

--- a/releases/trustworthy-transition-release-candidate-v0.3.json
+++ b/releases/trustworthy-transition-release-candidate-v0.3.json
@@ -7,6 +7,7 @@
   "repository": "safal207/Liminal",
   "target": {
     "branch": "main",
+    "initial_head": "426bf5c41a6215b0fef1e9ca59df00a880491c14",
     "expected_head": "426bf5c41a6215b0fef1e9ca59df00a880491c14",
     "drift_policy": "REFRESH_REQUIRED"
   },
@@ -117,7 +118,8 @@
     "NON_MERGE_COMMIT_STRATEGY_USED"
   ],
   "claim_boundary": {
-    "pre_merge_candidate_only": true,
+    "release_candidate_only": true,
+    "final_main_manifest": false,
     "semantic_conformance_replaced": false,
     "code_review_replaced": false,
     "branch_protection_replaced": false,

--- a/tools/verify_trustworthy_transition_release_train.py
+++ b/tools/verify_trustworthy_transition_release_train.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify the trustworthy-transition release train and pinned GitHub state."""
+"""Verify the trustworthy-transition release train and its pinned GitHub state."""
 
 from __future__ import annotations
 
@@ -18,12 +18,13 @@ PROFILE = "org.liminal.trustworthy-transition.release-train.v0.1"
 RECEIPT_SCHEMA = "org.liminal.trustworthy-transition.release-train-receipt.v0.1"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
-ALLOWED_TRAIN_STATES = {"OPEN_STACKED", "MERGED"}
-REQUIRED_BLOCKERS = {
-    "CODEX_REVIEW_PENDING",
-    "STACK_NOT_MERGED",
-    "FINAL_MAIN_MANIFEST_NOT_ISSUED",
+PHASE_BY_MERGED_COUNT = {
+    0: "PRE_MERGE_FROZEN",
+    1: "STAGE_1_MERGED",
+    2: "STAGE_2_MERGED",
+    3: "STACK_MERGED_PENDING_FINAL",
 }
+ALLOWED_CODEX_STATES = {"PENDING", "PASSED"}
 REQUIRED_INVALIDATION_RULES = {
     "TARGET_HEAD_CHANGED",
     "PINNED_PR_HEAD_CHANGED",
@@ -38,7 +39,7 @@ REQUIRED_INVALIDATION_RULES = {
 
 
 class TrainVerificationError(ValueError):
-    """Raised when the release train or its live pins are inconsistent."""
+    """Raised when the manifest or live release-train state is inconsistent."""
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -109,6 +110,60 @@ def require_string_list(value: Any, label: str) -> list[str]:
     return value
 
 
+def expected_blockers(codex_status: str, merged_count: int) -> set[str]:
+    blockers = {"FINAL_MAIN_MANIFEST_NOT_ISSUED"}
+    if codex_status != "PASSED":
+        blockers.add("CODEX_REVIEW_PENDING")
+    if merged_count != 3:
+        blockers.add("STACK_NOT_MERGED")
+    return blockers
+
+
+def verify_stage_runs(stage: dict[str, Any], label: str) -> list[dict[str, Any]]:
+    runs = stage.get("workflow_runs")
+    if not isinstance(runs, list) or not runs:
+        raise TrainVerificationError(f"{label}.workflow_runs must be non-empty")
+    seen_ids: set[int] = set()
+    seen_names: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(runs):
+        run = require_object(raw, f"{label}.workflow_runs[{index}]")
+        if set(run) != {"name", "run_id"}:
+            raise TrainVerificationError(f"{label}.workflow_runs[{index}] keys invalid")
+        name = require_text(run["name"], f"{label}.workflow_runs[{index}].name")
+        run_id = require_positive_int(
+            run["run_id"], f"{label}.workflow_runs[{index}].run_id"
+        )
+        if name in seen_names or run_id in seen_ids:
+            raise TrainVerificationError(f"{label} workflow run pins must be unique")
+        seen_names.add(name)
+        seen_ids.add(run_id)
+        normalized.append({"name": name, "run_id": run_id})
+    return normalized
+
+
+def verify_receipt(
+    stage: dict[str, Any], runs: list[dict[str, Any]], label: str
+) -> dict[str, Any]:
+    receipt = require_object(stage.get("receipt"), f"{label}.receipt")
+    if set(receipt) != {
+        "workflow_run_id",
+        "artifact_id",
+        "artifact_name",
+        "artifact_digest",
+    }:
+        raise TrainVerificationError(f"{label}.receipt keys invalid")
+    run_id = require_positive_int(
+        receipt["workflow_run_id"], f"{label}.receipt.workflow_run_id"
+    )
+    if run_id not in {run["run_id"] for run in runs}:
+        raise TrainVerificationError(f"{label} receipt run is not pinned in workflow_runs")
+    require_positive_int(receipt["artifact_id"], f"{label}.receipt.artifact_id")
+    require_text(receipt["artifact_name"], f"{label}.receipt.artifact_name")
+    require_digest(receipt["artifact_digest"], f"{label}.receipt.artifact_digest")
+    return receipt
+
+
 def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     required_root = {
         "schema_version",
@@ -131,57 +186,46 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             f"manifest keys invalid: missing={sorted(required_root - set(manifest))}, "
             f"unknown={sorted(set(manifest) - required_root)}"
         )
-    if manifest["schema_version"] != 1 or manifest["profile"] != PROFILE:
+    if manifest.get("schema_version") != 1 or manifest.get("profile") != PROFILE:
         raise TrainVerificationError("manifest schema/profile mismatch")
     require_text(manifest["candidate_id"], "candidate_id")
-    if manifest["candidate_state"] != "PRE_MERGE_FROZEN":
-        raise TrainVerificationError("candidate_state must be PRE_MERGE_FROZEN")
     if require_bool(manifest["release_ready"], "release_ready"):
-        raise TrainVerificationError("pre-merge candidate must not claim release readiness")
-    repository = require_text(manifest["repository"], "repository")
-    if repository != "safal207/Liminal":
+        raise TrainVerificationError("release candidate must not claim final release readiness")
+    if require_text(manifest["repository"], "repository") != "safal207/Liminal":
         raise TrainVerificationError("repository pin mismatch")
 
     target = require_object(manifest["target"], "target")
-    if set(target) != {"branch", "expected_head", "drift_policy"}:
+    if set(target) != {"branch", "initial_head", "expected_head", "drift_policy"}:
         raise TrainVerificationError("target keys invalid")
     if target["branch"] != "main" or target["drift_policy"] != "REFRESH_REQUIRED":
         raise TrainVerificationError("target branch/drift policy mismatch")
-    target_head = require_sha(target["expected_head"], "target.expected_head")
+    initial_head = require_sha(target["initial_head"], "target.initial_head")
+    expected_target_head = require_sha(target["expected_head"], "target.expected_head")
 
     policy = require_object(manifest["merge_policy"], "merge_policy")
-    expected_policy = {
+    if policy != {
         "required_method": "merge_commit",
         "forbidden_methods": ["squash", "rebase"],
         "preserve_successor_head": True,
         "retarget_immediate_successor_only": True,
         "rerun_after_retarget": True,
         "final_main_manifest_required": True,
-    }
-    if policy != expected_policy:
-        raise TrainVerificationError("merge policy must preserve stacked ancestry")
+    }:
+        raise TrainVerificationError("merge policy must preserve stack ancestry")
 
     review = require_object(manifest["review_policy"], "review_policy")
-    if review != {
-        "coderabbit_required": True,
-        "codex_required": True,
-        "codex_status": "PENDING",
-    }:
-        raise TrainVerificationError("review policy must keep mandatory Codex pending")
-
-    blockers = set(require_string_list(manifest["release_blockers"], "release_blockers"))
-    if blockers != REQUIRED_BLOCKERS:
-        raise TrainVerificationError("release blockers mismatch")
-    invalidation = set(
-        require_string_list(manifest["invalidation_rules"], "invalidation_rules")
-    )
-    if invalidation != REQUIRED_INVALIDATION_RULES:
-        raise TrainVerificationError("invalidation rule coverage mismatch")
-    require_text(manifest["next_action"], "next_action")
+    if set(review) != {"coderabbit_required", "codex_required", "codex_status"}:
+        raise TrainVerificationError("review policy keys invalid")
+    if review["coderabbit_required"] is not True or review["codex_required"] is not True:
+        raise TrainVerificationError("CodeRabbit and Codex must remain mandatory")
+    codex_status = require_text(review["codex_status"], "review_policy.codex_status")
+    if codex_status not in ALLOWED_CODEX_STATES:
+        raise TrainVerificationError("review_policy.codex_status is invalid")
 
     boundary = require_object(manifest["claim_boundary"], "claim_boundary")
     if boundary != {
-        "pre_merge_candidate_only": True,
+        "release_candidate_only": True,
+        "final_main_manifest": False,
         "semantic_conformance_replaced": False,
         "code_review_replaced": False,
         "branch_protection_replaced": False,
@@ -189,18 +233,25 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     }:
         raise TrainVerificationError("claim boundary mismatch")
 
-    stages = manifest["stages"]
-    if not isinstance(stages, list) or len(stages) != 3:
+    invalidation = set(
+        require_string_list(manifest["invalidation_rules"], "invalidation_rules")
+    )
+    if invalidation != REQUIRED_INVALIDATION_RULES:
+        raise TrainVerificationError("invalidation rule coverage mismatch")
+    require_text(manifest["next_action"], "next_action")
+
+    raw_stages = manifest["stages"]
+    if not isinstance(raw_stages, list) or len(raw_stages) != 3:
         raise TrainVerificationError("stages must contain exactly three entries")
 
-    normalized: list[dict[str, Any]] = []
+    stages: list[dict[str, Any]] = []
     seen_prs: set[int] = set()
     seen_heads: set[str] = set()
-    merged_prefix = True
-    for index, raw in enumerate(stages):
+    open_seen = False
+    for index, raw in enumerate(raw_stages):
         label = f"stages[{index}]"
         stage = require_object(raw, label)
-        required_stage = {
+        required = {
             "order",
             "layer",
             "pull_request",
@@ -216,32 +267,29 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             "required_commit_statuses",
             "receipt",
         }
-        optional_stage = {"merge_commit_sha"}
-        missing = required_stage - set(stage)
-        unknown = set(stage) - required_stage - optional_stage
-        if missing or unknown:
-            raise TrainVerificationError(
-                f"{label} keys invalid: missing={sorted(missing)}, unknown={sorted(unknown)}"
-            )
+        optional = {"merge_commit_sha"}
+        if required - set(stage) or set(stage) - required - optional:
+            raise TrainVerificationError(f"{label} keys invalid")
         order = require_positive_int(stage["order"], f"{label}.order")
         if order != index + 1:
             raise TrainVerificationError("stage order must be contiguous")
         require_text(stage["layer"], f"{label}.layer")
         pr_number = require_positive_int(stage["pull_request"], f"{label}.pull_request")
         if pr_number in seen_prs:
-            raise TrainVerificationError("pull request pins must be unique")
+            raise TrainVerificationError("stage PR numbers must be unique")
         seen_prs.add(pr_number)
-        train_state = require_text(stage["train_state"], f"{label}.train_state")
-        if train_state not in ALLOWED_TRAIN_STATES:
+
+        state = require_text(stage["train_state"], f"{label}.train_state")
+        if state not in {"OPEN_STACKED", "MERGED"}:
             raise TrainVerificationError(f"{label}.train_state is invalid")
-        if train_state == "MERGED":
-            if not merged_prefix:
+        if state == "OPEN_STACKED":
+            open_seen = True
+            if "merge_commit_sha" in stage:
+                raise TrainVerificationError("open stage must not pin merge_commit_sha")
+        else:
+            if open_seen:
                 raise TrainVerificationError("merged stages must form a prefix")
             require_sha(stage.get("merge_commit_sha"), f"{label}.merge_commit_sha")
-        else:
-            merged_prefix = False
-            if "merge_commit_sha" in stage:
-                raise TrainVerificationError("open stage must not pin a merge commit")
 
         head_branch = require_text(stage["head_branch"], f"{label}.head_branch")
         head_sha = require_sha(stage["head_sha"], f"{label}.head_sha")
@@ -259,75 +307,42 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             stage["delta_commits"], f"{label}.delta_commits"
         )
 
-        predecessor = stage["predecessor_pull_request"]
         if index == 0:
-            if predecessor is not None:
+            if stage["predecessor_pull_request"] is not None:
                 raise TrainVerificationError("first stage must not have a predecessor")
-            if base_branch != target["branch"] or base_sha != target_head:
-                raise TrainVerificationError("first stage must be based on frozen target head")
-            if ancestry_parent != target_head:
-                raise TrainVerificationError("first ancestry parent must equal target head")
+            if base_branch != "main":
+                raise TrainVerificationError("first stage base branch must be main")
+            if ancestry_parent != initial_head:
+                raise TrainVerificationError("first stage ancestry parent must be initial main")
         else:
-            previous = normalized[index - 1]
-            if predecessor != previous["pull_request"]:
+            previous = stages[index - 1]
+            if stage["predecessor_pull_request"] != previous["pull_request"]:
                 raise TrainVerificationError("successor predecessor PR mismatch")
             if ancestry_parent != previous["head_sha"]:
-                raise TrainVerificationError("successor ancestry must point to predecessor head")
-            if previous["train_state"] == "OPEN_STACKED":
-                if base_branch != previous["head_branch"] or base_sha != previous["head_sha"]:
-                    raise TrainVerificationError(
-                        "open stacked successor must target predecessor branch and head"
-                    )
-            else:
-                if base_branch != target["branch"] or base_sha != target_head:
-                    raise TrainVerificationError(
-                        "successor of merged stage must be retargeted to current target head"
-                    )
+                raise TrainVerificationError("successor ancestry parent mismatch")
+            if state == "OPEN_STACKED":
+                if previous["train_state"] == "OPEN_STACKED":
+                    if base_branch != previous["head_branch"] or base_sha != previous["head_sha"]:
+                        raise TrainVerificationError(
+                            "open successor must target its open predecessor branch and head"
+                        )
+                else:
+                    if base_branch != "main" or base_sha != expected_target_head:
+                        raise TrainVerificationError(
+                            "successor of merged stage must target current main head"
+                        )
+            elif base_branch != "main":
+                raise TrainVerificationError("merged successor must have been retargeted to main")
 
-        runs = stage["workflow_runs"]
-        if not isinstance(runs, list) or not runs:
-            raise TrainVerificationError(f"{label}.workflow_runs must be non-empty")
-        run_ids: set[int] = set()
-        run_names: set[str] = set()
-        normalized_runs: list[dict[str, Any]] = []
-        for run_index, run_raw in enumerate(runs):
-            run = require_object(run_raw, f"{label}.workflow_runs[{run_index}]")
-            if set(run) != {"name", "run_id"}:
-                raise TrainVerificationError("workflow run keys invalid")
-            name = require_text(run["name"], f"{label}.workflow_runs[{run_index}].name")
-            run_id = require_positive_int(
-                run["run_id"], f"{label}.workflow_runs[{run_index}].run_id"
-            )
-            if name in run_names or run_id in run_ids:
-                raise TrainVerificationError("workflow run names and IDs must be unique per stage")
-            run_names.add(name)
-            run_ids.add(run_id)
-            normalized_runs.append({"name": name, "run_id": run_id})
-
+        runs = verify_stage_runs(stage, label)
         statuses = require_string_list(
             stage["required_commit_statuses"], f"{label}.required_commit_statuses"
         )
         if statuses != ["CodeRabbit"]:
-            raise TrainVerificationError("every stage must require CodeRabbit success")
+            raise TrainVerificationError("each stage must require CodeRabbit success")
+        receipt = verify_receipt(stage, runs, label)
 
-        receipt = require_object(stage["receipt"], f"{label}.receipt")
-        if set(receipt) != {
-            "workflow_run_id",
-            "artifact_id",
-            "artifact_name",
-            "artifact_digest",
-        }:
-            raise TrainVerificationError("receipt keys invalid")
-        receipt_run = require_positive_int(
-            receipt["workflow_run_id"], f"{label}.receipt.workflow_run_id"
-        )
-        if receipt_run not in run_ids:
-            raise TrainVerificationError("receipt workflow run must be pinned in workflow_runs")
-        require_positive_int(receipt["artifact_id"], f"{label}.receipt.artifact_id")
-        require_text(receipt["artifact_name"], f"{label}.receipt.artifact_name")
-        require_digest(receipt["artifact_digest"], f"{label}.receipt.artifact_digest")
-
-        normalized.append(
+        stages.append(
             {
                 **stage,
                 "head_branch": head_branch,
@@ -336,15 +351,32 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                 "expected_base_sha": base_sha,
                 "ancestry_parent_sha": ancestry_parent,
                 "delta_commits": delta_commits,
-                "workflow_runs": normalized_runs,
+                "workflow_runs": runs,
+                "receipt": receipt,
             }
         )
 
-    if [stage["pull_request"] for stage in normalized] != [110, 113, 116]:
+    if [stage["pull_request"] for stage in stages] != [110, 113, 116]:
         raise TrainVerificationError("canonical train must pin PRs 110, 113, and 116")
-    if any(stage["train_state"] != "OPEN_STACKED" for stage in normalized):
-        raise TrainVerificationError("PRE_MERGE_FROZEN candidate must have all stages open")
-    return normalized
+
+    merged_count = sum(stage["train_state"] == "MERGED" for stage in stages)
+    expected_phase = PHASE_BY_MERGED_COUNT[merged_count]
+    if manifest["candidate_state"] != expected_phase:
+        raise TrainVerificationError(
+            f"candidate_state must be {expected_phase} for {merged_count} merged stages"
+        )
+    if merged_count == 0:
+        if expected_target_head != initial_head:
+            raise TrainVerificationError("pre-merge target head must equal initial head")
+    else:
+        last_merged = stages[merged_count - 1]
+        if expected_target_head != last_merged["merge_commit_sha"]:
+            raise TrainVerificationError("target head must equal latest merged-stage commit")
+
+    blockers = set(require_string_list(manifest["release_blockers"], "release_blockers"))
+    if blockers != expected_blockers(codex_status, merged_count):
+        raise TrainVerificationError("release blockers do not match train/review state")
+    return stages
 
 
 class GitHubClient:
@@ -353,9 +385,8 @@ class GitHubClient:
         self.api_url = api_url.rstrip("/")
 
     def get(self, path: str) -> Any:
-        url = f"{self.api_url}/{path.lstrip('/')}"
         request = urllib.request.Request(
-            url,
+            f"{self.api_url}/{path.lstrip('/')}",
             headers={
                 "Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {self.token}",
@@ -375,10 +406,15 @@ class GitHubClient:
             raise TrainVerificationError(f"GitHub API request failed for {path}: {error}") from error
 
 
+def latest_status(statuses: list[dict[str, Any]], context: str) -> dict[str, Any] | None:
+    matching = [status for status in statuses if status.get("context") == context]
+    if not matching:
+        return None
+    return max(matching, key=lambda status: status.get("updated_at") or "")
+
+
 def verify_live(
-    manifest: dict[str, Any],
-    stages: list[dict[str, Any]],
-    client: GitHubClient,
+    manifest: dict[str, Any], stages: list[dict[str, Any]], client: GitHubClient
 ) -> dict[str, Any]:
     repository = manifest["repository"]
     encoded_repo = "/".join(urllib.parse.quote(part, safe="") for part in repository.split("/"))
@@ -386,40 +422,43 @@ def verify_live(
     branch = client.get(
         f"repos/{encoded_repo}/branches/{urllib.parse.quote(target['branch'], safe='')}"
     )
-    actual_target_head = branch.get("commit", {}).get("sha")
-    if actual_target_head != target["expected_head"]:
+    target_head = branch.get("commit", {}).get("sha")
+    if target_head != target["expected_head"]:
         raise TrainVerificationError(
-            f"target head drifted: {actual_target_head} != {target['expected_head']}"
+            f"target head drifted: {target_head} != {target['expected_head']}"
         )
 
     live_stages: list[dict[str, Any]] = []
     for stage in stages:
         pr_number = stage["pull_request"]
         pr = client.get(f"repos/{encoded_repo}/pulls/{pr_number}")
-        if stage["train_state"] == "OPEN_STACKED":
-            if pr.get("state") != "open" or pr.get("merged") is True:
-                raise TrainVerificationError(f"PR #{pr_number} is no longer open and unmerged")
-        else:
-            if pr.get("state") != "closed" or pr.get("merged") is not True:
-                raise TrainVerificationError(f"PR #{pr_number} is not merged as pinned")
-            merge_sha = stage["merge_commit_sha"]
-            if pr.get("merge_commit_sha") != merge_sha:
-                raise TrainVerificationError(f"PR #{pr_number} merge commit changed")
-            merge_commit = client.get(f"repos/{encoded_repo}/commits/{merge_sha}")
-            parents = [parent.get("sha") for parent in merge_commit.get("parents", [])]
-            if len(parents) < 2 or stage["head_sha"] not in parents:
-                raise TrainVerificationError(
-                    f"PR #{pr_number} was not preserved as a merge-commit parent"
-                )
-
         if pr.get("head", {}).get("ref") != stage["head_branch"]:
             raise TrainVerificationError(f"PR #{pr_number} head branch drifted")
         if pr.get("head", {}).get("sha") != stage["head_sha"]:
             raise TrainVerificationError(f"PR #{pr_number} head SHA drifted")
         if pr.get("base", {}).get("ref") != stage["expected_base_branch"]:
             raise TrainVerificationError(f"PR #{pr_number} base branch drifted")
-        if pr.get("base", {}).get("sha") != stage["expected_base_sha"]:
-            raise TrainVerificationError(f"PR #{pr_number} base SHA drifted")
+
+        if stage["train_state"] == "OPEN_STACKED":
+            if pr.get("state") != "open" or pr.get("merged") is True:
+                raise TrainVerificationError(f"PR #{pr_number} is not open and unmerged")
+            if pr.get("base", {}).get("sha") != stage["expected_base_sha"]:
+                raise TrainVerificationError(f"PR #{pr_number} base SHA drifted")
+        else:
+            if pr.get("state") != "closed" or pr.get("merged") is not True:
+                raise TrainVerificationError(f"PR #{pr_number} is not merged")
+            merge_sha = stage["merge_commit_sha"]
+            if pr.get("merge_commit_sha") != merge_sha:
+                raise TrainVerificationError(f"PR #{pr_number} merge commit drifted")
+            merge_commit = client.get(f"repos/{encoded_repo}/commits/{merge_sha}")
+            parents = [parent.get("sha") for parent in merge_commit.get("parents", [])]
+            if len(parents) != 2 or set(parents) != {
+                stage["expected_base_sha"],
+                stage["head_sha"],
+            }:
+                raise TrainVerificationError(
+                    f"PR #{pr_number} was not merged with the pinned two-parent merge commit"
+                )
 
         compare = client.get(
             f"repos/{encoded_repo}/compare/{stage['ancestry_parent_sha']}...{stage['head_sha']}"
@@ -431,70 +470,49 @@ def verify_live(
         if compare.get("merge_base_commit", {}).get("sha") != stage["ancestry_parent_sha"]:
             raise TrainVerificationError(f"PR #{pr_number} merge base changed")
 
-        live_runs: list[dict[str, Any]] = []
+        normalized_runs: list[dict[str, Any]] = []
         for run_pin in stage["workflow_runs"]:
             run = client.get(f"repos/{encoded_repo}/actions/runs/{run_pin['run_id']}")
             if run.get("name") != run_pin["name"]:
-                raise TrainVerificationError(
-                    f"workflow run {run_pin['run_id']} name changed"
-                )
+                raise TrainVerificationError(f"workflow run {run_pin['run_id']} name changed")
             if run.get("head_sha") != stage["head_sha"]:
-                raise TrainVerificationError(
-                    f"workflow run {run_pin['run_id']} is not bound to pinned head"
-                )
+                raise TrainVerificationError(f"workflow run {run_pin['run_id']} head changed")
             if run.get("event") != "pull_request":
-                raise TrainVerificationError(
-                    f"workflow run {run_pin['run_id']} is not a pull-request run"
-                )
+                raise TrainVerificationError(f"workflow run {run_pin['run_id']} event changed")
             if run.get("status") != "completed" or run.get("conclusion") != "success":
-                raise TrainVerificationError(
-                    f"workflow run {run_pin['run_id']} is not completed successfully"
-                )
-            live_runs.append(
-                {
-                    "name": run_pin["name"],
-                    "run_id": run_pin["run_id"],
-                    "conclusion": "success",
-                }
+                raise TrainVerificationError(f"workflow run {run_pin['run_id']} is not green")
+            normalized_runs.append(
+                {"name": run_pin["name"], "run_id": run_pin["run_id"], "conclusion": "success"}
             )
 
-        receipt_pin = stage["receipt"]
-        artifact = client.get(
-            f"repos/{encoded_repo}/actions/artifacts/{receipt_pin['artifact_id']}"
-        )
-        if artifact.get("name") != receipt_pin["artifact_name"]:
+        receipt = stage["receipt"]
+        artifact = client.get(f"repos/{encoded_repo}/actions/artifacts/{receipt['artifact_id']}")
+        if artifact.get("name") != receipt["artifact_name"]:
             raise TrainVerificationError(f"PR #{pr_number} artifact name changed")
-        if artifact.get("digest") != receipt_pin["artifact_digest"]:
+        if artifact.get("digest") != receipt["artifact_digest"]:
             raise TrainVerificationError(f"PR #{pr_number} artifact digest changed")
         if artifact.get("expired") is not False:
-            raise TrainVerificationError(f"PR #{pr_number} artifact is expired")
+            raise TrainVerificationError(f"PR #{pr_number} artifact expired")
         artifact_run = artifact.get("workflow_run") or {}
-        if artifact_run.get("id") != receipt_pin["workflow_run_id"]:
+        if artifact_run.get("id") != receipt["workflow_run_id"]:
             raise TrainVerificationError(f"PR #{pr_number} artifact run changed")
         if artifact_run.get("head_sha") != stage["head_sha"]:
             raise TrainVerificationError(f"PR #{pr_number} artifact head binding changed")
 
         combined = client.get(f"repos/{encoded_repo}/commits/{stage['head_sha']}/status")
-        statuses = combined.get("statuses") or []
         normalized_statuses: list[dict[str, str]] = []
-        for required_context in stage["required_commit_statuses"]:
-            matches = [item for item in statuses if item.get("context") == required_context]
-            if not matches:
+        for context in stage["required_commit_statuses"]:
+            status = latest_status(combined.get("statuses") or [], context)
+            if status is None or status.get("state") != "success":
                 raise TrainVerificationError(
-                    f"PR #{pr_number} missing required status {required_context}"
+                    f"PR #{pr_number} required status {context} is not successful"
                 )
-            latest = max(matches, key=lambda item: item.get("updated_at") or "")
-            if latest.get("state") != "success":
-                raise TrainVerificationError(
-                    f"PR #{pr_number} status {required_context} is not successful"
-                )
-            normalized_statuses.append(
-                {"context": required_context, "state": "success"}
-            )
+            normalized_statuses.append({"context": context, "state": "success"})
 
         live_stages.append(
             {
                 "pull_request": pr_number,
+                "train_state": stage["train_state"],
                 "state": pr.get("state"),
                 "draft": bool(pr.get("draft")),
                 "head_sha": stage["head_sha"],
@@ -502,44 +520,38 @@ def verify_live(
                 "base_sha": stage["expected_base_sha"],
                 "ancestry_parent_sha": stage["ancestry_parent_sha"],
                 "delta_commits": stage["delta_commits"],
-                "workflow_runs": live_runs,
+                "workflow_runs": normalized_runs,
                 "statuses": normalized_statuses,
                 "artifact": {
-                    "artifact_id": receipt_pin["artifact_id"],
-                    "name": receipt_pin["artifact_name"],
-                    "digest": receipt_pin["artifact_digest"],
+                    "artifact_id": receipt["artifact_id"],
+                    "name": receipt["artifact_name"],
+                    "digest": receipt["artifact_digest"],
                 },
             }
         )
 
     live_state = {
-        "target": {"branch": target["branch"], "head_sha": actual_target_head},
+        "target": {"branch": target["branch"], "head_sha": target_head},
         "stages": live_stages,
     }
-    return {
-        "live_state": live_state,
-        "live_state_digest": digest_json(live_state),
-    }
+    return {"live_state": live_state, "live_state_digest": digest_json(live_state)}
 
 
 def build_receipt(
-    manifest: dict[str, Any],
-    stages: list[dict[str, Any]],
-    live_result: dict[str, Any] | None,
+    manifest: dict[str, Any], stages: list[dict[str, Any]], live: dict[str, Any] | None
 ) -> dict[str, Any]:
     receipt: dict[str, Any] = {
         "schema": RECEIPT_SCHEMA,
         "profile": PROFILE,
         "verdict": "PASS",
-        "mode": "LIVE" if live_result is not None else "OFFLINE",
+        "mode": "LIVE" if live else "OFFLINE",
         "candidate_id": manifest["candidate_id"],
         "candidate_state": manifest["candidate_state"],
         "manifest_digest": digest_json(manifest),
-        "target_head": manifest["target"]["expected_head"],
-        "stage_count": len(stages),
-        "stage_heads": {
-            str(stage["pull_request"]): stage["head_sha"] for stage in stages
-        },
+        "initial_target_head": manifest["target"]["initial_head"],
+        "current_target_head": manifest["target"]["expected_head"],
+        "merged_stage_count": sum(stage["train_state"] == "MERGED" for stage in stages),
+        "stage_heads": {str(stage["pull_request"]): stage["head_sha"] for stage in stages},
         "receipt_artifacts": {
             str(stage["pull_request"]): stage["receipt"]["artifact_digest"]
             for stage in stages
@@ -550,8 +562,8 @@ def build_receipt(
         "next_action": manifest["next_action"],
         "claim_boundary": manifest["claim_boundary"],
     }
-    if live_result is not None:
-        receipt.update(live_result)
+    if live:
+        receipt.update(live)
     return receipt
 
 
@@ -577,14 +589,18 @@ def main() -> None:
         configured_repository = os.environ.get("GITHUB_REPOSITORY")
         if configured_repository and configured_repository != manifest["repository"]:
             raise TrainVerificationError("GITHUB_REPOSITORY does not match manifest")
-        client = GitHubClient(
-            token=token,
-            api_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        live_result = verify_live(
+            manifest,
+            stages,
+            GitHubClient(token, os.environ.get("GITHUB_API_URL", "https://api.github.com")),
         )
-        live_result = verify_live(manifest, stages, client)
 
-    receipt = build_receipt(manifest, stages, live_result)
-    rendered = json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    rendered = json.dumps(
+        build_receipt(manifest, stages, live_result),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(rendered, encoding="utf-8")

--- a/tools/verify_trustworthy_transition_release_train.py
+++ b/tools/verify_trustworthy_transition_release_train.py
@@ -24,7 +24,7 @@ PHASE_BY_MERGED_COUNT = {
     2: "STAGE_2_MERGED",
     3: "STACK_MERGED_PENDING_FINAL",
 }
-ALLOWED_CODEX_STATES = {"PENDING", "PASSED"}
+ALLOWED_REVIEW_STATES = {"PENDING", "PASSED"}
 REQUIRED_INVALIDATION_RULES = {
     "TARGET_HEAD_CHANGED",
     "PINNED_PR_HEAD_CHANGED",
@@ -110,13 +110,32 @@ def require_string_list(value: Any, label: str) -> list[str]:
     return value
 
 
-def expected_blockers(codex_status: str, merged_count: int) -> set[str]:
+def expected_blockers(
+    coderabbit_status: str, codex_status: str, merged_count: int
+) -> set[str]:
     blockers = {"FINAL_MAIN_MANIFEST_NOT_ISSUED"}
+    if coderabbit_status != "PASSED":
+        blockers.add("CODERABBIT_REVIEW_PENDING")
     if codex_status != "PASSED":
         blockers.add("CODEX_REVIEW_PENDING")
     if merged_count != 3:
         blockers.add("STACK_NOT_MERGED")
     return blockers
+
+
+def expected_next_action(
+    coderabbit_status: str, codex_status: str, merged_count: int
+) -> str:
+    if coderabbit_status != "PASSED":
+        return "COMPLETE_CODERABBIT_REVIEW"
+    if codex_status != "PASSED":
+        return "COMPLETE_CODEX_REVIEW"
+    return {
+        0: "MERGE_PR_110_WITH_MERGE_COMMIT",
+        1: "RETARGET_PR_113_TO_MAIN_RERUN_AND_REPIN",
+        2: "RETARGET_PR_116_TO_MAIN_RERUN_AND_REPIN",
+        3: "ISSUE_FINAL_MAIN_MANIFEST",
+    }[merged_count]
 
 
 def verify_stage_runs(stage: dict[str, Any], label: str) -> list[dict[str, Any]]:
@@ -214,12 +233,22 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
         raise TrainVerificationError("merge policy must preserve stack ancestry")
 
     review = require_object(manifest["review_policy"], "review_policy")
-    if set(review) != {"coderabbit_required", "codex_required", "codex_status"}:
+    if set(review) != {
+        "coderabbit_required",
+        "coderabbit_status",
+        "codex_required",
+        "codex_status",
+    }:
         raise TrainVerificationError("review policy keys invalid")
     if review["coderabbit_required"] is not True or review["codex_required"] is not True:
         raise TrainVerificationError("CodeRabbit and Codex must remain mandatory")
+    coderabbit_status = require_text(
+        review["coderabbit_status"], "review_policy.coderabbit_status"
+    )
     codex_status = require_text(review["codex_status"], "review_policy.codex_status")
-    if codex_status not in ALLOWED_CODEX_STATES:
+    if coderabbit_status not in ALLOWED_REVIEW_STATES:
+        raise TrainVerificationError("review_policy.coderabbit_status is invalid")
+    if codex_status not in ALLOWED_REVIEW_STATES:
         raise TrainVerificationError("review_policy.codex_status is invalid")
 
     boundary = require_object(manifest["claim_boundary"], "claim_boundary")
@@ -238,7 +267,7 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     )
     if invalidation != REQUIRED_INVALIDATION_RULES:
         raise TrainVerificationError("invalidation rule coverage mismatch")
-    require_text(manifest["next_action"], "next_action")
+    next_action = require_text(manifest["next_action"], "next_action")
 
     raw_stages = manifest["stages"]
     if not isinstance(raw_stages, list) or len(raw_stages) != 3:
@@ -312,6 +341,8 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                 raise TrainVerificationError("first stage must not have a predecessor")
             if base_branch != "main":
                 raise TrainVerificationError("first stage base branch must be main")
+            if base_sha != initial_head:
+                raise TrainVerificationError("first stage base SHA must equal initial main")
             if ancestry_parent != initial_head:
                 raise TrainVerificationError("first stage ancestry parent must be initial main")
         else:
@@ -331,8 +362,13 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                         raise TrainVerificationError(
                             "successor of merged stage must target current main head"
                         )
-            elif base_branch != "main":
-                raise TrainVerificationError("merged successor must have been retargeted to main")
+            else:
+                if base_branch != "main":
+                    raise TrainVerificationError("merged successor must have been retargeted to main")
+                if base_sha != previous["merge_commit_sha"]:
+                    raise TrainVerificationError(
+                        "merged successor base SHA must equal predecessor merge commit"
+                    )
 
         runs = verify_stage_runs(stage, label)
         statuses = require_string_list(
@@ -374,13 +410,38 @@ def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             raise TrainVerificationError("target head must equal latest merged-stage commit")
 
     blockers = set(require_string_list(manifest["release_blockers"], "release_blockers"))
-    if blockers != expected_blockers(codex_status, merged_count):
+    if blockers != expected_blockers(coderabbit_status, codex_status, merged_count):
         raise TrainVerificationError("release blockers do not match train/review state")
+    expected_action = expected_next_action(coderabbit_status, codex_status, merged_count)
+    if next_action != expected_action:
+        raise TrainVerificationError(
+            f"next_action must be {expected_action} for the verified review/train state"
+        )
     return stages
 
 
 class GitHubClient:
     def __init__(self, token: str, api_url: str) -> None:
+        parsed = urllib.parse.urlparse(api_url)
+        allowed_hosts = {
+            host.strip().lower()
+            for host in os.environ.get(
+                "TRUSTWORTHY_TRAIN_ALLOWED_GITHUB_API_HOSTS", "api.github.com"
+            ).split(",")
+            if host.strip()
+        }
+        host = (parsed.hostname or "").lower()
+        if (
+            parsed.scheme != "https"
+            or host not in allowed_hosts
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise TrainVerificationError(
+                "GITHUB_API_URL must be HTTPS and use an explicitly allowed GitHub API host"
+            )
         self.token = token
         self.api_url = api_url.rstrip("/")
 
@@ -557,6 +618,7 @@ def build_receipt(
             for stage in stages
         },
         "merge_method": manifest["merge_policy"]["required_method"],
+        "review_policy": manifest["review_policy"],
         "release_ready": manifest["release_ready"],
         "release_blockers": manifest["release_blockers"],
         "next_action": manifest["next_action"],

--- a/tools/verify_trustworthy_transition_release_train.py
+++ b/tools/verify_trustworthy_transition_release_train.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Verify the trustworthy-transition release train and pinned GitHub state."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+PROFILE = "org.liminal.trustworthy-transition.release-train.v0.1"
+RECEIPT_SCHEMA = "org.liminal.trustworthy-transition.release-train-receipt.v0.1"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+ALLOWED_TRAIN_STATES = {"OPEN_STACKED", "MERGED"}
+REQUIRED_BLOCKERS = {
+    "CODEX_REVIEW_PENDING",
+    "STACK_NOT_MERGED",
+    "FINAL_MAIN_MANIFEST_NOT_ISSUED",
+}
+REQUIRED_INVALIDATION_RULES = {
+    "TARGET_HEAD_CHANGED",
+    "PINNED_PR_HEAD_CHANGED",
+    "PINNED_PR_BASE_CHANGED",
+    "ANCESTRY_CHANGED",
+    "WORKFLOW_RUN_CHANGED_OR_FAILED",
+    "RECEIPT_ARTIFACT_CHANGED_OR_EXPIRED",
+    "REQUIRED_COMMIT_STATUS_NOT_SUCCESSFUL",
+    "SUCCESSOR_HEAD_CHANGED_AFTER_RETARGET",
+    "NON_MERGE_COMMIT_STRATEGY_USED",
+}
+
+
+class TrainVerificationError(ValueError):
+    """Raised when the release train or its live pins are inconsistent."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise TrainVerificationError(f"cannot read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise TrainVerificationError(f"invalid JSON in {path}: {error.msg}") from error
+    if not isinstance(value, dict):
+        raise TrainVerificationError(f"{path} root must be an object")
+    return value
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def digest_json(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TrainVerificationError(f"{label} must be an object")
+    return value
+
+
+def require_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TrainVerificationError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def require_bool(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise TrainVerificationError(f"{label} must be a boolean")
+    return value
+
+
+def require_positive_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise TrainVerificationError(f"{label} must be a positive integer")
+    return value
+
+
+def require_sha(value: Any, label: str) -> str:
+    sha = require_text(value, label)
+    if not SHA_RE.fullmatch(sha):
+        raise TrainVerificationError(f"{label} must be a lowercase 40-character SHA")
+    return sha
+
+
+def require_digest(value: Any, label: str) -> str:
+    digest = require_text(value, label)
+    if not DIGEST_RE.fullmatch(digest):
+        raise TrainVerificationError(f"{label} must be a sha256 reference")
+    return digest
+
+
+def require_string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise TrainVerificationError(f"{label} must be an array of strings")
+    if len(value) != len(set(value)):
+        raise TrainVerificationError(f"{label} must not contain duplicates")
+    return value
+
+
+def verify_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    required_root = {
+        "schema_version",
+        "profile",
+        "candidate_id",
+        "candidate_state",
+        "release_ready",
+        "repository",
+        "target",
+        "merge_policy",
+        "review_policy",
+        "stages",
+        "next_action",
+        "release_blockers",
+        "invalidation_rules",
+        "claim_boundary",
+    }
+    if set(manifest) != required_root:
+        raise TrainVerificationError(
+            f"manifest keys invalid: missing={sorted(required_root - set(manifest))}, "
+            f"unknown={sorted(set(manifest) - required_root)}"
+        )
+    if manifest["schema_version"] != 1 or manifest["profile"] != PROFILE:
+        raise TrainVerificationError("manifest schema/profile mismatch")
+    require_text(manifest["candidate_id"], "candidate_id")
+    if manifest["candidate_state"] != "PRE_MERGE_FROZEN":
+        raise TrainVerificationError("candidate_state must be PRE_MERGE_FROZEN")
+    if require_bool(manifest["release_ready"], "release_ready"):
+        raise TrainVerificationError("pre-merge candidate must not claim release readiness")
+    repository = require_text(manifest["repository"], "repository")
+    if repository != "safal207/Liminal":
+        raise TrainVerificationError("repository pin mismatch")
+
+    target = require_object(manifest["target"], "target")
+    if set(target) != {"branch", "expected_head", "drift_policy"}:
+        raise TrainVerificationError("target keys invalid")
+    if target["branch"] != "main" or target["drift_policy"] != "REFRESH_REQUIRED":
+        raise TrainVerificationError("target branch/drift policy mismatch")
+    target_head = require_sha(target["expected_head"], "target.expected_head")
+
+    policy = require_object(manifest["merge_policy"], "merge_policy")
+    expected_policy = {
+        "required_method": "merge_commit",
+        "forbidden_methods": ["squash", "rebase"],
+        "preserve_successor_head": True,
+        "retarget_immediate_successor_only": True,
+        "rerun_after_retarget": True,
+        "final_main_manifest_required": True,
+    }
+    if policy != expected_policy:
+        raise TrainVerificationError("merge policy must preserve stacked ancestry")
+
+    review = require_object(manifest["review_policy"], "review_policy")
+    if review != {
+        "coderabbit_required": True,
+        "codex_required": True,
+        "codex_status": "PENDING",
+    }:
+        raise TrainVerificationError("review policy must keep mandatory Codex pending")
+
+    blockers = set(require_string_list(manifest["release_blockers"], "release_blockers"))
+    if blockers != REQUIRED_BLOCKERS:
+        raise TrainVerificationError("release blockers mismatch")
+    invalidation = set(
+        require_string_list(manifest["invalidation_rules"], "invalidation_rules")
+    )
+    if invalidation != REQUIRED_INVALIDATION_RULES:
+        raise TrainVerificationError("invalidation rule coverage mismatch")
+    require_text(manifest["next_action"], "next_action")
+
+    boundary = require_object(manifest["claim_boundary"], "claim_boundary")
+    if boundary != {
+        "pre_merge_candidate_only": True,
+        "semantic_conformance_replaced": False,
+        "code_review_replaced": False,
+        "branch_protection_replaced": False,
+        "human_merge_decision_replaced": False,
+    }:
+        raise TrainVerificationError("claim boundary mismatch")
+
+    stages = manifest["stages"]
+    if not isinstance(stages, list) or len(stages) != 3:
+        raise TrainVerificationError("stages must contain exactly three entries")
+
+    normalized: list[dict[str, Any]] = []
+    seen_prs: set[int] = set()
+    seen_heads: set[str] = set()
+    merged_prefix = True
+    for index, raw in enumerate(stages):
+        label = f"stages[{index}]"
+        stage = require_object(raw, label)
+        required_stage = {
+            "order",
+            "layer",
+            "pull_request",
+            "train_state",
+            "head_branch",
+            "head_sha",
+            "expected_base_branch",
+            "expected_base_sha",
+            "ancestry_parent_sha",
+            "predecessor_pull_request",
+            "delta_commits",
+            "workflow_runs",
+            "required_commit_statuses",
+            "receipt",
+        }
+        optional_stage = {"merge_commit_sha"}
+        missing = required_stage - set(stage)
+        unknown = set(stage) - required_stage - optional_stage
+        if missing or unknown:
+            raise TrainVerificationError(
+                f"{label} keys invalid: missing={sorted(missing)}, unknown={sorted(unknown)}"
+            )
+        order = require_positive_int(stage["order"], f"{label}.order")
+        if order != index + 1:
+            raise TrainVerificationError("stage order must be contiguous")
+        require_text(stage["layer"], f"{label}.layer")
+        pr_number = require_positive_int(stage["pull_request"], f"{label}.pull_request")
+        if pr_number in seen_prs:
+            raise TrainVerificationError("pull request pins must be unique")
+        seen_prs.add(pr_number)
+        train_state = require_text(stage["train_state"], f"{label}.train_state")
+        if train_state not in ALLOWED_TRAIN_STATES:
+            raise TrainVerificationError(f"{label}.train_state is invalid")
+        if train_state == "MERGED":
+            if not merged_prefix:
+                raise TrainVerificationError("merged stages must form a prefix")
+            require_sha(stage.get("merge_commit_sha"), f"{label}.merge_commit_sha")
+        else:
+            merged_prefix = False
+            if "merge_commit_sha" in stage:
+                raise TrainVerificationError("open stage must not pin a merge commit")
+
+        head_branch = require_text(stage["head_branch"], f"{label}.head_branch")
+        head_sha = require_sha(stage["head_sha"], f"{label}.head_sha")
+        if head_sha in seen_heads:
+            raise TrainVerificationError("stage head SHAs must be unique")
+        seen_heads.add(head_sha)
+        base_branch = require_text(
+            stage["expected_base_branch"], f"{label}.expected_base_branch"
+        )
+        base_sha = require_sha(stage["expected_base_sha"], f"{label}.expected_base_sha")
+        ancestry_parent = require_sha(
+            stage["ancestry_parent_sha"], f"{label}.ancestry_parent_sha"
+        )
+        delta_commits = require_positive_int(
+            stage["delta_commits"], f"{label}.delta_commits"
+        )
+
+        predecessor = stage["predecessor_pull_request"]
+        if index == 0:
+            if predecessor is not None:
+                raise TrainVerificationError("first stage must not have a predecessor")
+            if base_branch != target["branch"] or base_sha != target_head:
+                raise TrainVerificationError("first stage must be based on frozen target head")
+            if ancestry_parent != target_head:
+                raise TrainVerificationError("first ancestry parent must equal target head")
+        else:
+            previous = normalized[index - 1]
+            if predecessor != previous["pull_request"]:
+                raise TrainVerificationError("successor predecessor PR mismatch")
+            if ancestry_parent != previous["head_sha"]:
+                raise TrainVerificationError("successor ancestry must point to predecessor head")
+            if previous["train_state"] == "OPEN_STACKED":
+                if base_branch != previous["head_branch"] or base_sha != previous["head_sha"]:
+                    raise TrainVerificationError(
+                        "open stacked successor must target predecessor branch and head"
+                    )
+            else:
+                if base_branch != target["branch"] or base_sha != target_head:
+                    raise TrainVerificationError(
+                        "successor of merged stage must be retargeted to current target head"
+                    )
+
+        runs = stage["workflow_runs"]
+        if not isinstance(runs, list) or not runs:
+            raise TrainVerificationError(f"{label}.workflow_runs must be non-empty")
+        run_ids: set[int] = set()
+        run_names: set[str] = set()
+        normalized_runs: list[dict[str, Any]] = []
+        for run_index, run_raw in enumerate(runs):
+            run = require_object(run_raw, f"{label}.workflow_runs[{run_index}]")
+            if set(run) != {"name", "run_id"}:
+                raise TrainVerificationError("workflow run keys invalid")
+            name = require_text(run["name"], f"{label}.workflow_runs[{run_index}].name")
+            run_id = require_positive_int(
+                run["run_id"], f"{label}.workflow_runs[{run_index}].run_id"
+            )
+            if name in run_names or run_id in run_ids:
+                raise TrainVerificationError("workflow run names and IDs must be unique per stage")
+            run_names.add(name)
+            run_ids.add(run_id)
+            normalized_runs.append({"name": name, "run_id": run_id})
+
+        statuses = require_string_list(
+            stage["required_commit_statuses"], f"{label}.required_commit_statuses"
+        )
+        if statuses != ["CodeRabbit"]:
+            raise TrainVerificationError("every stage must require CodeRabbit success")
+
+        receipt = require_object(stage["receipt"], f"{label}.receipt")
+        if set(receipt) != {
+            "workflow_run_id",
+            "artifact_id",
+            "artifact_name",
+            "artifact_digest",
+        }:
+            raise TrainVerificationError("receipt keys invalid")
+        receipt_run = require_positive_int(
+            receipt["workflow_run_id"], f"{label}.receipt.workflow_run_id"
+        )
+        if receipt_run not in run_ids:
+            raise TrainVerificationError("receipt workflow run must be pinned in workflow_runs")
+        require_positive_int(receipt["artifact_id"], f"{label}.receipt.artifact_id")
+        require_text(receipt["artifact_name"], f"{label}.receipt.artifact_name")
+        require_digest(receipt["artifact_digest"], f"{label}.receipt.artifact_digest")
+
+        normalized.append(
+            {
+                **stage,
+                "head_branch": head_branch,
+                "head_sha": head_sha,
+                "expected_base_branch": base_branch,
+                "expected_base_sha": base_sha,
+                "ancestry_parent_sha": ancestry_parent,
+                "delta_commits": delta_commits,
+                "workflow_runs": normalized_runs,
+            }
+        )
+
+    if [stage["pull_request"] for stage in normalized] != [110, 113, 116]:
+        raise TrainVerificationError("canonical train must pin PRs 110, 113, and 116")
+    if any(stage["train_state"] != "OPEN_STACKED" for stage in normalized):
+        raise TrainVerificationError("PRE_MERGE_FROZEN candidate must have all stages open")
+    return normalized
+
+
+class GitHubClient:
+    def __init__(self, token: str, api_url: str) -> None:
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+
+    def get(self, path: str) -> Any:
+        url = f"{self.api_url}/{path.lstrip('/')}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "liminal-release-train-verifier",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")[:1000]
+            raise TrainVerificationError(
+                f"GitHub API {error.code} for {path}: {body}"
+            ) from error
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+            raise TrainVerificationError(f"GitHub API request failed for {path}: {error}") from error
+
+
+def verify_live(
+    manifest: dict[str, Any],
+    stages: list[dict[str, Any]],
+    client: GitHubClient,
+) -> dict[str, Any]:
+    repository = manifest["repository"]
+    encoded_repo = "/".join(urllib.parse.quote(part, safe="") for part in repository.split("/"))
+    target = manifest["target"]
+    branch = client.get(
+        f"repos/{encoded_repo}/branches/{urllib.parse.quote(target['branch'], safe='')}"
+    )
+    actual_target_head = branch.get("commit", {}).get("sha")
+    if actual_target_head != target["expected_head"]:
+        raise TrainVerificationError(
+            f"target head drifted: {actual_target_head} != {target['expected_head']}"
+        )
+
+    live_stages: list[dict[str, Any]] = []
+    for stage in stages:
+        pr_number = stage["pull_request"]
+        pr = client.get(f"repos/{encoded_repo}/pulls/{pr_number}")
+        if stage["train_state"] == "OPEN_STACKED":
+            if pr.get("state") != "open" or pr.get("merged") is True:
+                raise TrainVerificationError(f"PR #{pr_number} is no longer open and unmerged")
+        else:
+            if pr.get("state") != "closed" or pr.get("merged") is not True:
+                raise TrainVerificationError(f"PR #{pr_number} is not merged as pinned")
+            merge_sha = stage["merge_commit_sha"]
+            if pr.get("merge_commit_sha") != merge_sha:
+                raise TrainVerificationError(f"PR #{pr_number} merge commit changed")
+            merge_commit = client.get(f"repos/{encoded_repo}/commits/{merge_sha}")
+            parents = [parent.get("sha") for parent in merge_commit.get("parents", [])]
+            if len(parents) < 2 or stage["head_sha"] not in parents:
+                raise TrainVerificationError(
+                    f"PR #{pr_number} was not preserved as a merge-commit parent"
+                )
+
+        if pr.get("head", {}).get("ref") != stage["head_branch"]:
+            raise TrainVerificationError(f"PR #{pr_number} head branch drifted")
+        if pr.get("head", {}).get("sha") != stage["head_sha"]:
+            raise TrainVerificationError(f"PR #{pr_number} head SHA drifted")
+        if pr.get("base", {}).get("ref") != stage["expected_base_branch"]:
+            raise TrainVerificationError(f"PR #{pr_number} base branch drifted")
+        if pr.get("base", {}).get("sha") != stage["expected_base_sha"]:
+            raise TrainVerificationError(f"PR #{pr_number} base SHA drifted")
+
+        compare = client.get(
+            f"repos/{encoded_repo}/compare/{stage['ancestry_parent_sha']}...{stage['head_sha']}"
+        )
+        if compare.get("status") != "ahead" or compare.get("behind_by") != 0:
+            raise TrainVerificationError(f"PR #{pr_number} ancestry is not a strict descendant")
+        if compare.get("ahead_by") != stage["delta_commits"]:
+            raise TrainVerificationError(f"PR #{pr_number} delta commit count changed")
+        if compare.get("merge_base_commit", {}).get("sha") != stage["ancestry_parent_sha"]:
+            raise TrainVerificationError(f"PR #{pr_number} merge base changed")
+
+        live_runs: list[dict[str, Any]] = []
+        for run_pin in stage["workflow_runs"]:
+            run = client.get(f"repos/{encoded_repo}/actions/runs/{run_pin['run_id']}")
+            if run.get("name") != run_pin["name"]:
+                raise TrainVerificationError(
+                    f"workflow run {run_pin['run_id']} name changed"
+                )
+            if run.get("head_sha") != stage["head_sha"]:
+                raise TrainVerificationError(
+                    f"workflow run {run_pin['run_id']} is not bound to pinned head"
+                )
+            if run.get("event") != "pull_request":
+                raise TrainVerificationError(
+                    f"workflow run {run_pin['run_id']} is not a pull-request run"
+                )
+            if run.get("status") != "completed" or run.get("conclusion") != "success":
+                raise TrainVerificationError(
+                    f"workflow run {run_pin['run_id']} is not completed successfully"
+                )
+            live_runs.append(
+                {
+                    "name": run_pin["name"],
+                    "run_id": run_pin["run_id"],
+                    "conclusion": "success",
+                }
+            )
+
+        receipt_pin = stage["receipt"]
+        artifact = client.get(
+            f"repos/{encoded_repo}/actions/artifacts/{receipt_pin['artifact_id']}"
+        )
+        if artifact.get("name") != receipt_pin["artifact_name"]:
+            raise TrainVerificationError(f"PR #{pr_number} artifact name changed")
+        if artifact.get("digest") != receipt_pin["artifact_digest"]:
+            raise TrainVerificationError(f"PR #{pr_number} artifact digest changed")
+        if artifact.get("expired") is not False:
+            raise TrainVerificationError(f"PR #{pr_number} artifact is expired")
+        artifact_run = artifact.get("workflow_run") or {}
+        if artifact_run.get("id") != receipt_pin["workflow_run_id"]:
+            raise TrainVerificationError(f"PR #{pr_number} artifact run changed")
+        if artifact_run.get("head_sha") != stage["head_sha"]:
+            raise TrainVerificationError(f"PR #{pr_number} artifact head binding changed")
+
+        combined = client.get(f"repos/{encoded_repo}/commits/{stage['head_sha']}/status")
+        statuses = combined.get("statuses") or []
+        normalized_statuses: list[dict[str, str]] = []
+        for required_context in stage["required_commit_statuses"]:
+            matches = [item for item in statuses if item.get("context") == required_context]
+            if not matches:
+                raise TrainVerificationError(
+                    f"PR #{pr_number} missing required status {required_context}"
+                )
+            latest = max(matches, key=lambda item: item.get("updated_at") or "")
+            if latest.get("state") != "success":
+                raise TrainVerificationError(
+                    f"PR #{pr_number} status {required_context} is not successful"
+                )
+            normalized_statuses.append(
+                {"context": required_context, "state": "success"}
+            )
+
+        live_stages.append(
+            {
+                "pull_request": pr_number,
+                "state": pr.get("state"),
+                "draft": bool(pr.get("draft")),
+                "head_sha": stage["head_sha"],
+                "base_branch": stage["expected_base_branch"],
+                "base_sha": stage["expected_base_sha"],
+                "ancestry_parent_sha": stage["ancestry_parent_sha"],
+                "delta_commits": stage["delta_commits"],
+                "workflow_runs": live_runs,
+                "statuses": normalized_statuses,
+                "artifact": {
+                    "artifact_id": receipt_pin["artifact_id"],
+                    "name": receipt_pin["artifact_name"],
+                    "digest": receipt_pin["artifact_digest"],
+                },
+            }
+        )
+
+    live_state = {
+        "target": {"branch": target["branch"], "head_sha": actual_target_head},
+        "stages": live_stages,
+    }
+    return {
+        "live_state": live_state,
+        "live_state_digest": digest_json(live_state),
+    }
+
+
+def build_receipt(
+    manifest: dict[str, Any],
+    stages: list[dict[str, Any]],
+    live_result: dict[str, Any] | None,
+) -> dict[str, Any]:
+    receipt: dict[str, Any] = {
+        "schema": RECEIPT_SCHEMA,
+        "profile": PROFILE,
+        "verdict": "PASS",
+        "mode": "LIVE" if live_result is not None else "OFFLINE",
+        "candidate_id": manifest["candidate_id"],
+        "candidate_state": manifest["candidate_state"],
+        "manifest_digest": digest_json(manifest),
+        "target_head": manifest["target"]["expected_head"],
+        "stage_count": len(stages),
+        "stage_heads": {
+            str(stage["pull_request"]): stage["head_sha"] for stage in stages
+        },
+        "receipt_artifacts": {
+            str(stage["pull_request"]): stage["receipt"]["artifact_digest"]
+            for stage in stages
+        },
+        "merge_method": manifest["merge_policy"]["required_method"],
+        "release_ready": manifest["release_ready"],
+        "release_blockers": manifest["release_blockers"],
+        "next_action": manifest["next_action"],
+        "claim_boundary": manifest["claim_boundary"],
+    }
+    if live_result is not None:
+        receipt.update(live_result)
+    return receipt
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=root / "releases/trustworthy-transition-release-candidate-v0.3.json",
+    )
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    manifest = load_json(args.manifest)
+    stages = verify_manifest(manifest)
+    live_result: dict[str, Any] | None = None
+    if args.live:
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            raise TrainVerificationError("GITHUB_TOKEN is required for --live")
+        configured_repository = os.environ.get("GITHUB_REPOSITORY")
+        if configured_repository and configured_repository != manifest["repository"]:
+            raise TrainVerificationError("GITHUB_REPOSITORY does not match manifest")
+        client = GitHubClient(
+            token=token,
+            api_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        )
+        live_result = verify_live(manifest, stages, client)
+
+    receipt = build_receipt(manifest, stages, live_result)
+    rendered = json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except TrainVerificationError as error:
+        raise SystemExit(f"release train verification failed: {error}") from error


### PR DESCRIPTION
## Summary

Implements #117 as a stacked follow-up to PR #116.

Adds a machine-checkable release-candidate manifest and a read-only live GitHub verifier for the merge train:

```text
#110 → #113 → #116
```

## Base dependency

This PR is intentionally stacked on PR #116 and base branch `feat/durability-assurance-v0.3`. It must not be retargeted to `main` or merged before #110, #113, and #116 land in order.

## Added

- progressive release-candidate manifest;
- offline schema and invariant verifier;
- read-only live GitHub API verification;
- exact PR head/base/ancestry pins;
- exact successful workflow-run pins;
- receipt artifact ID, name, digest, expiry, run, and head-binding checks;
- two-parent merge-commit verification for completed stages;
- four progressive train phases;
- machine-derived review blockers and `next_action`;
- deterministic offline and live receipts;
- hardened credential and API-host handling;
- reviewer-facing merge and retarget procedure.

## Frozen train

- `main`: `426bf5c41a6215b0fef1e9ca59df00a880491c14`
- PR #110: `2ac45920526526bbe42fcbcff7d7fca80cd667eb`
- PR #113: `b50ef4d90a76fbd5b5d2e835f85e348081f4110f`
- PR #116: `c2864dd9f57e962064f24b6cc6368f647ebaaea4`

Exact ancestry is 6 + 5 + 7 commits with no branch behind its ancestry parent.

## Merge policy

- merge commits only;
- squash and rebase merge are forbidden for the stack;
- retarget only the immediate successor after each merge;
- preserve successor head SHA;
- rerun and repin workflows and receipt artifacts after every retarget;
- fail closed if `main`, a PR head/base, ancestry, workflow, artifact, review state, or required status drifts.

## Candidate phases

- `PRE_MERGE_FROZEN`
- `STAGE_1_MERGED`
- `STAGE_2_MERGED`
- `STACK_MERGED_PENDING_FINAL`

The candidate always keeps `release_ready = false`. A separate final manifest must be generated from `main` after the complete stack lands.

## Validation

Green on current head `c8d116625a28751db5719bc70302f7bd311cb08d`:

- release-manifest offline verification;
- live GitHub release-train verification;
- canonical/v0.1/v0.2/v0.3 conformance regression;
- Python WebSocket integration;
- CodeRabbit.

The live verifier confirmed:

- current `main` head;
- PR #110/#113/#116 exact heads and bases;
- strict 6 + 5 + 7 commit ancestry;
- pinned successful workflow runs;
- latest required CodeRabbit statuses;
- receipt artifact names, digests, expiry state, workflow binding, and head binding.

Release-train receipt artifact:

- artifact ID: `7950908306`
- digest: `sha256:6884aa1969a0db8b50d7bd3bb6039d79af50394e3d9179877b2cc82572228e33`

## CodeRabbit findings addressed

- checkout credential persistence disabled;
- bearer token restricted to an allowlisted HTTPS GitHub API host;
- both CodeRabbit and Codex modeled as mandatory review gates;
- CodeRabbit pending state added to blockers;
- `next_action` derived from review and merge phase;
- offline base-SHA invariants enforced for initial and merged stages.

All review threads are resolved.

## Current machine state

```text
candidate_state = PRE_MERGE_FROZEN
coderabbit_status = PASSED
codex_status = PENDING
next_action = COMPLETE_CODEX_REVIEW
release_ready = false
```

## Boundary

The verifier does not merge PRs, update branches, replace semantic conformance, replace CodeRabbit/Codex, bypass branch protection, or make a human release decision.

## Merge gate

Keep this PR draft. Do not merge until:

1. mandatory Codex review passes;
2. #110, #113, and #116 merge in order using merge commits;
3. the manifest advances and live-verifies after every stage;
4. this PR is retargeted to `main` without losing its tooling commits;
5. a separate final `main` release manifest is issued and verified.

Closes #117 after merge.